### PR TITLE
Bugfix - Null pointer exception on Cursors

### DIFF
--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsProvider.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsProvider.java
@@ -63,7 +63,9 @@ public class ContactsProvider {
             try {
                 justMe = loadContactsFrom(cursor);
             } finally {
-                cursor.close();
+                if (cursor != null) {
+                    cursor.close();
+                }
             }
         }
 
@@ -80,7 +82,9 @@ public class ContactsProvider {
             try {
                 everyoneElse = loadContactsFrom(cursor);
             } finally {
-                cursor.close();
+                if (cursor != null) {
+                    cursor.close();
+                }
             }
         }
 


### PR DESCRIPTION
Via [this StackOverflow](http://stackoverflow.com/questions/13080540/what-causes-androids-contentresolver-query-to-return-null), it looks like `ContentResover.query` can return `null` when there's nothing to resolve or the resolver is not available.

The crash report [can be found here](http://crashes.to/s/7bc64015c82)

Ideally I wanted to avoid `loadContactsFrom(cursor)` all together when there's no `cursor`, but didn't have time to refactor too much.