### PR TITLE
Add postal address(es) to contacts response

### DIFF
--- a/ios/RCTContacts/RCTContacts.m
+++ b/ios/RCTContacts/RCTContacts.m
@@ -155,9 +155,33 @@ withCallback:(RCTResponseSenderBlock) callback
     [email setObject: emailLabel forKey:@"label"];
     [emailAddreses addObject:email];
   }
-  //end emails
 
   [contact setObject: emailAddreses forKey:@"emailAddresses"];
+  //end emails
+
+  //handle postal addresses
+  NSMutableArray *postalAddresses = [[NSMutableArray alloc] init];
+
+  ABMultiValueRef multiAddresses = ABRecordCopyValue(person, kABPersonAddressProperty);
+  for (CFIndex i=0;i<ABMultiValueGetCount(multiAddresses);i++) {
+    NSDictionary *addressDictionary =(__bridge NSDictionary *) ABMultiValueCopyValueAtIndex(multiAddresses, i);
+    CFStringRef addressLabelRef = ABMultiValueCopyLabelAtIndex(multiAddresses, i);
+    NSString *addressLabel = (__bridge_transfer NSString *) ABAddressBookCopyLocalizedLabel(addressLabelRef);
+
+    if (addressLabelRef) {
+      CFRelease(addressLabelRef);
+    }
+
+    NSMutableDictionary* postalAddress = [[NSMutableDictionary alloc] init];
+
+    [postalAddress setObject: addressDictionary forKey:@"address"];
+    [postalAddress setObject: addressLabel forKey:@"label"];
+
+    [postalAddresses addObject:postalAddress];
+  }
+
+  [contact setObject: postalAddresses forKey:@"postalAddresses"];
+  //end postal addresses
 
   [contact setObject: [self getABPersonThumbnailFilepath:person] forKey:@"thumbnailPath"];
 

--- a/ios/RCTContacts/RCTContacts.m
+++ b/ios/RCTContacts/RCTContacts.m
@@ -183,15 +183,34 @@ withCallback:(RCTResponseSenderBlock) callback
       CFRelease(addressLabelRef);
     }
 
-    NSMutableDictionary* postalAddress = [[NSMutableDictionary alloc] init];
+    NSDictionary *keyMap = @{
+      @"Street": @"street",
+      @"ZIP": @"zipCode",
+      @"City": @"city",
+      @"CountryCode": @"countryCode",
+      @"State": @"state",
+      @"Country": @"country",
+    };
 
-    [postalAddress setObject: addressDictionary forKey:@"address"];
+    NSMutableDictionary *postalAddress = [[self mappedDictionary:addressDictionary withNewKeys:keyMap] mutableCopy];
     [postalAddress setObject: addressLabel forKey:@"label"];
 
     [postalAddresses addObject:postalAddress];
   }
 
   return postalAddresses;
+}
+
+- (NSDictionary *)mappedDictionary:(NSDictionary *)dictionary withNewKeys:(NSDictionary *)keyMap
+{
+  NSMutableDictionary *newDictionary = [dictionary mutableCopy];
+
+  for (NSString *key in keyMap) {
+    [newDictionary setObject:[dictionary objectForKey:key] forKey:[keyMap objectForKey:key]];
+    [newDictionary removeObjectForKey:key];
+  }
+
+  return newDictionary;
 }
 
 -(NSString *) getABPersonThumbnailFilepath:(ABRecordRef) person

--- a/ios/RCTContacts/RCTContacts.m
+++ b/ios/RCTContacts/RCTContacts.m
@@ -206,8 +206,12 @@ withCallback:(RCTResponseSenderBlock) callback
   NSMutableDictionary *newDictionary = [dictionary mutableCopy];
 
   for (NSString *key in keyMap) {
-    [newDictionary setObject:[dictionary objectForKey:key] forKey:[keyMap objectForKey:key]];
-    [newDictionary removeObjectForKey:key];
+    NSObject *object = [dictionary objectForKey:key];
+
+    if (object) {
+      [newDictionary setObject:[dictionary objectForKey:key] forKey:[keyMap objectForKey:key]];
+      [newDictionary removeObjectForKey:key];
+    }
   }
 
   return newDictionary;

--- a/ios/RCTContacts/RCTContacts.m
+++ b/ios/RCTContacts/RCTContacts.m
@@ -111,7 +111,16 @@ withCallback:(RCTResponseSenderBlock) callback
     return nil;
   }
 
-  //handle phone numbers
+  [contact setObject: [self getPhoneNumbersForPerson:person] forKey:@"phoneNumbers"];
+  [contact setObject: [self getEmailAddressesForPerson:person] forKey:@"emailAddresses"];
+  [contact setObject: [self getPostalAddressesForPerson:person] forKey:@"postalAddresses"];
+  [contact setObject: [self getABPersonThumbnailFilepath:person] forKey:@"thumbnailPath"];
+
+  return contact;
+}
+
+- (NSArray *) getPhoneNumbersForPerson:(ABRecordRef) person
+{
   NSMutableArray *phoneNumbers = [[NSMutableArray alloc] init];
 
   ABMultiValueRef multiPhones = ABRecordCopyValue(person, kABPersonPhoneProperty);
@@ -132,10 +141,11 @@ withCallback:(RCTResponseSenderBlock) callback
     [phoneNumbers addObject:phone];
   }
 
-  [contact setObject: phoneNumbers forKey:@"phoneNumbers"];
-  //end phone numbers
+  return phoneNumbers;
+}
 
-  //handle emails
+- (NSArray *) getEmailAddressesForPerson:(ABRecordRef) person
+{
   NSMutableArray *emailAddreses = [[NSMutableArray alloc] init];
 
   ABMultiValueRef multiEmails = ABRecordCopyValue(person, kABPersonEmailProperty);
@@ -156,10 +166,11 @@ withCallback:(RCTResponseSenderBlock) callback
     [emailAddreses addObject:email];
   }
 
-  [contact setObject: emailAddreses forKey:@"emailAddresses"];
-  //end emails
+  return emailAddreses;
+}
 
-  //handle postal addresses
+- (NSArray *) getPostalAddressesForPerson:(ABRecordRef) person
+{
   NSMutableArray *postalAddresses = [[NSMutableArray alloc] init];
 
   ABMultiValueRef multiAddresses = ABRecordCopyValue(person, kABPersonAddressProperty);
@@ -180,12 +191,7 @@ withCallback:(RCTResponseSenderBlock) callback
     [postalAddresses addObject:postalAddress];
   }
 
-  [contact setObject: postalAddresses forKey:@"postalAddresses"];
-  //end postal addresses
-
-  [contact setObject: [self getABPersonThumbnailFilepath:person] forKey:@"thumbnailPath"];
-
-  return contact;
+  return postalAddresses;
 }
 
 -(NSString *) getABPersonThumbnailFilepath:(ABRecordRef) person


### PR DESCRIPTION
This adds an array of labeled postal addresses to each contact returned from the API. The format of that postal address object depends on which fields are available, but looks something like: 

```
{
  label: "work",
  city: "San Rafael",
  countryCode: "us",
  state: "CA",
  street: "1741 Kearny Street",
  zipCode: "94901",
}
```

I also took the opportunity to clean up a bit of the object parsing method by splitting up the collections properties calculation into their own methods. You can see those changes specifically in cc94aef.
