### PR TITLE
Run getAll() in a background thread on Android to improve performance

### DIFF
--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
@@ -4,6 +4,7 @@ import android.content.ContentProviderOperation;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.pm.PackageManager;
+import android.os.AsyncTask;
 import android.provider.ContactsContract;
 import android.provider.ContactsContract.CommonDataKinds;
 import android.provider.ContactsContract.CommonDataKinds.StructuredName;
@@ -30,14 +31,19 @@ public class ContactsManager extends ReactContextBaseJavaModule {
      * queries CommonDataKinds.Contactables to get phones and emails
      */
     @ReactMethod
-    public void getAll(Callback callback) {
-        Context context = getReactApplicationContext();
-        ContentResolver cr = context.getContentResolver();
+    public void getAll(final Callback callback) {
+        AsyncTask.execute(new Runnable() {
+            @Override
+            public void run() {
+                Context context = getReactApplicationContext();
+                ContentResolver cr = context.getContentResolver();
 
-        ContactsProvider contactsProvider = new ContactsProvider(cr, context);
-        WritableArray contacts = contactsProvider.getContacts();
+                ContactsProvider contactsProvider = new ContactsProvider(cr, context);
+                WritableArray contacts = contactsProvider.getContacts();
 
-        callback.invoke(null, contacts);
+                callback.invoke(null, contacts);
+            }
+        });
     }
 
     /*


### PR DESCRIPTION
Getting all the contacts is a heavy operation, and seems to cause significant performance impact to apps while it's running despite being called asynchronously from React Native.

In my testing I've identified that by ensuring getAll() runs completely on a background thread using AsyncTask, the performance of the React Native app is unaffected while it runs.