### PR TITLE
ANDROID: optimization: faster getAll() 

### DIFF
--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsProvider.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsProvider.java
@@ -153,7 +153,8 @@ public class ContactsProvider {
 
             String rawPhotoURI = cursor.getString(cursor.getColumnIndex(Contactables.PHOTO_URI));
             if (!TextUtils.isEmpty(rawPhotoURI)) {
-                contact.photoUri = getPhotoURIFromContactURI(rawPhotoURI, contactId);
+                //contact.photoUri = getPhotoURIFromContactURI(rawPhotoURI, contactId);  // this is slow because it generates new temporary image for each contacts
+				contact.photoUri = Uri.parse(rawPhotoURI).toString(); // fast
             }
 
             if (mimeType.equals(StructuredName.CONTENT_ITEM_TYPE)) {


### PR DESCRIPTION
Hello
On android, is there a reason to create an image file for each contact when calling getAll() ?
This PR just send back the imageUri, and then getAll() is very much faster.
It works fine for me on my app, but I don't know if it's ok or not for everyone.
