### PR TITLE
Fix Thumbnail path issues, Add Contact addresses

### DIFF
--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
@@ -33,6 +33,31 @@ public class ContactsManager extends ReactContextBaseJavaModule {
      */
     @ReactMethod
     public void getAll(final Callback callback) {
+        getAllImpl(false, callback);
+    }
+
+    /**
+     * Retrieves all contactable records, as {@link #getAll(Callback)} without copying image assets.
+     *
+     * Does not introduce overhead of copying assets.
+     * However, the <code>thumbnailPath</code> will be present, if can be retrieved without much effort.
+     *
+     * Introduced for iOS compatibility.
+     *
+     * @param callback callback
+     */
+    @ReactMethod
+    public void getAllWithoutPhotos(final Callback callback) {
+        getAllImpl(true, callback);
+    }
+
+    /**
+     * Retrieves contacts.
+     * Uses raw URI when <code>rawUri</code> is <code>true</code>, makes assets copy otherwise.
+     * @param rawUri flag if use raw URI or make resources copy
+     * @param callback callback
+     */
+    private void getAllImpl(final boolean rawUri, final Callback callback) {
         AsyncTask.execute(new Runnable() {
             @Override
             public void run() {
@@ -40,9 +65,29 @@ public class ContactsManager extends ReactContextBaseJavaModule {
                 ContentResolver cr = context.getContentResolver();
 
                 ContactsProvider contactsProvider = new ContactsProvider(cr, context);
-                WritableArray contacts = contactsProvider.getContacts();
+                WritableArray contacts = contactsProvider.getContacts(rawUri);
 
                 callback.invoke(null, contacts);
+            }
+        });
+    }
+
+    /**
+     * Retrieves <code>thumbnailPath</code> for contact, or <code>null</code> if not available.
+     * @param contactId contact identifier, <code>recordID</code>
+     * @param callback callback
+     */
+    @ReactMethod
+    public void getPhotoForId(final String contactId, final Callback callback) {
+        AsyncTask.execute(new Runnable() {
+            @Override
+            public void run() {
+                Context context = getReactApplicationContext();
+                ContentResolver cr = context.getContentResolver();
+                ContactsProvider contactsProvider = new ContactsProvider(cr, context);
+                String photoUri = contactsProvider.getPhotoUriFromContactId(contactId);
+
+                callback.invoke(null, photoUri);
             }
         });
     }

--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
@@ -85,7 +85,7 @@ public class ContactsManager extends ReactContextBaseJavaModule {
                 Context context = getReactApplicationContext();
                 ContentResolver cr = context.getContentResolver();
                 ContactsProvider contactsProvider = new ContactsProvider(cr, context);
-                String photoUri = contactsProvider.getPhotoUriFromContactId(contactId);
+                String photoUri = contactsProvider.getPhotoUriFromContactId(contactId, true);
 
                 callback.invoke(null, photoUri);
             }

--- a/ios/RCTContacts/RCTContacts.m
+++ b/ios/RCTContacts/RCTContacts.m
@@ -169,6 +169,45 @@ withCallback:(RCTResponseSenderBlock) callback
 
   [contact setObject: emailAddreses forKey:@"emailAddresses"];
 
+  NSMutableArray *postalAddresses = [[NSMutableArray alloc] init];
+  ABMultiValueRef multiPostalAddresses = ABRecordCopyValue(person, kABPersonAddressProperty);
+  for(CFIndex i=0;i<ABMultiValueGetCount(multiPostalAddresses);i++) {
+    NSMutableDictionary* address = [NSMutableDictionary dictionary];
+
+    NSDictionary *addressDict = (__bridge NSDictionary *)ABMultiValueCopyValueAtIndex(multiPostalAddresses, i);
+    NSString* street = [addressDict objectForKey:(NSString*)kABPersonAddressStreetKey];
+    if(street){
+      [address setObject:street forKey:@"street"];
+    }
+    NSString* city = [addressDict objectForKey:(NSString*)kABPersonAddressCityKey];
+    if(city){
+      [address setObject:city forKey:@"city"];
+    }
+    NSString* region = [addressDict objectForKey:(NSString*)kABPersonAddressStateKey];
+    if(region){
+      [address setObject:region forKey:@"region"];
+    }
+    NSString* postCode = [addressDict objectForKey:(NSString*)kABPersonAddressZIPKey];
+    if(postCode){
+      [address setObject:postCode forKey:@"postCode"];
+    }
+    NSString* country = [addressDict objectForKey:(NSString*)kABPersonAddressCountryCodeKey];
+    if(country){
+      [address setObject:country forKey:@"country"];
+    }
+
+    CFStringRef addresssLabelRef = ABMultiValueCopyLabelAtIndex(multiPostalAddresses, i);
+    NSString *addressLabel = (__bridge_transfer NSString *) ABAddressBookCopyLocalizedLabel(addresssLabelRef);
+    if(addresssLabelRef){
+      CFRelease(addresssLabelRef);
+    }
+    [address setObject:addressLabel forKey:@"label"];
+
+    [postalAddresses addObject:address];
+  }
+  CFRelease(multiPostalAddresses);
+  [contact setObject:postalAddresses forKey:@"postalAddresses"];
+
   [contact setObject: [self getABPersonThumbnailFilepath:person] forKey:@"thumbnailPath"];
 
   return contact;


### PR DESCRIPTION
Objective: performance. 

The more contacts with thumbnails you have in address book, the longer it takes to return it to RN, easily reaching seconds and more. With this change:
- Android does not create thumbnails copies to FS (the CONTENT_URI works fine with current RN).
- iOS returns list of contacts without thumbnails, which can be requested with further calls.

The new functionality is served with new methods, so backward compatibility is maintained; Android and iOS are coherent in API.