### PR TITLE
Added get(options, callback) for tailoring queries to one's needs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Rx support with [react-native-contacts-rx](https://github.com/JeanLebrument/reac
 | `addContact` | ✔ | ✔ |
 | `updateContact` | ✔ | ✔ |
 | `deleteContact` | ✔ | 😞 |
-| get with options | 😞 | 😞 |
+| get with options | 😞 | ✔ |
 | groups  | 😞 | 😞 |
 
 
@@ -22,13 +22,18 @@ Rx support with [react-native-contacts-rx](https://github.com/JeanLebrument/reac
 `updateContact` (contact, callback) - where contact is an object with a valid recordID  
 `deleteContact` (contact, callback) - where contact is an object with a valid recordID  
 `checkPermission` (callback) - checks permission to access Contacts  
-`requestPermission` (callback) - request permission to access Contacts
+`requestPermission` (callback) - request permission to access Contacts  
+`get` (options, callback) - returns contacts satisfying options object.  Currently just supports the `contactsWith` key on Android to optimize your query’s performance
 
+```js
+var Contacts = require('react-native-contacts')
+
+Contacts.get(
+   { contactsWith: [‘phone’] }, // Supports [‘phone’, ‘name’, ‘email’, ‘organization’] or any combo
+   (err, contacts) => { console.log(contacts) }
+)
+```
 ## Usage
-`getAll` is a database intensive process, and can take a long time to complete depending on the size of the contacts list. Because of this, it is recommended you access the `getAll` method before it is needed, and cache the results for future use.
-
-Also there is a lot of room for performance enhancements in both iOS and android. PR's welcome!
-
 ```js
 var Contacts = require('react-native-contacts')
 
@@ -40,6 +45,9 @@ Contacts.getAll((err, contacts) => {
   }
 })
 ```
+**Note** `getAll` is a database intensive process, and can take a long time to complete depending on the size of the contacts list. Because Android is particularly slow, it is recommended you use `get(options, …)` to try to optimize your query, to only fetch contacts that are relevant to your use case. See example above.
+
+Also there is a lot of room for performance enhancements in both iOS and android. PR's welcome!
 
 ## Example Contact Record
 ```js
@@ -202,7 +210,7 @@ On android permission request is done upon install so this function will only sh
 ## Todo
 - [ ] android feature parity
 - [ ] migrate iOS from AddressBook to Contacts
-- [ ] implement `get` with options
+- [ ] implement `get` with options on iOS
 - [ ] groups support
 
 ## LICENSE

--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
@@ -38,9 +38,39 @@ public class ContactsManager extends ReactContextBaseJavaModule {
             public void run() {
                 Context context = getReactApplicationContext();
                 ContentResolver cr = context.getContentResolver();
-
                 ContactsProvider contactsProvider = new ContactsProvider(cr, context);
-                WritableArray contacts = contactsProvider.getContacts();
+                WritableArray contacts = contactsProvider.getContacts(null);
+
+                callback.invoke(null, contacts);
+            }
+        });
+    }
+
+    /*
+     * Returns records relevant to options passed in.
+     * queries CommonDataKinds.Contactables to get phones and emails
+     * Options that can be passed:
+     * 'contactsWith' - array can be passed to optimize the query,
+     *   to just look contacts with a
+     *   'phone', 'email', 'name', or 'organization' (or any combo)
+     */
+    @ReactMethod
+    public void get(final ReadableMap options, final Callback callback) {
+        AsyncTask.execute(new Runnable() {
+            @Override
+            public void run() {
+                Context context = getReactApplicationContext();
+                ContentResolver cr = context.getContentResolver();
+                ReadableArray selections = options.getArray("contactsWith");
+                String[] contactSelections = null;
+                if (selections != null) {
+                    contactSelections = new String[selections.size()];
+                    for (int i = 0; i < selections.size(); i++) {
+                        contactSelections[i] = selections.getString(i);
+                    }
+                }
+                ContactsProvider contactsProvider = new ContactsProvider(cr, context);
+                WritableArray contacts = contactsProvider.getContacts(contactSelections);
 
                 callback.invoke(null, contacts);
             }


### PR DESCRIPTION

### Performance Enhancement For Android

On Android, queries of `getAll` are extremely slow.  Due to users' email accounts (gmail etc...) being connected to their contacts on android, email queries (as well as `getAll`) can take a really long time (~20+ seconds).

In my use case, I just need contacts with phone numbers, and querying just by populated phone fields significantly optimizes the query.   I added an `options` object to allow users to only query contacts containing certain fields populated:

`contactsWith` key in `options` object supports the following fields (Android only)
```
   ['email', 'phone', 'organization', 'name']
```

`get(options, callback)` on iOS just fails over to `getAll` so users can just filter on the callback side rather than having to look at `Platform.OS` before calling `get(options)`