### PR TITLE
add getContactByPhoneNumber to the Android API

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Rx support with [react-native-contacts-rx](https://github.com/JeanLebrument/reac
 | Feature | iOS | Android |
 | ------- | --- | ------- |
 | `getAll`  | ✔   | ✔ |
+| `getContactByPhoneNumber` | 😞 | ✔ |
 | `addContact` | ✔ | ✔ |
 | `updateContact` | ✔ | ✔ |
 | `deleteContact` | ✔ | 😞 |
@@ -20,6 +21,7 @@ Rx support with [react-native-contacts-rx](https://github.com/JeanLebrument/reac
 `getAll` (callback) - returns *all* contacts as an array of objects  
 `getAllWithoutPhotos` - same as `getAll` on Android, but on iOS it will not return uris for contact photos (because there's a significant overhead in creating the images)
 `getPhotoForId(contactId, callback)` - returns a URI (or null) for a contacts photo
+`getContactByPhoneNumber` (phoneNumber, callback) - Returns contact details for a specific phone number
 `addContact` (contact, callback) - adds a contact to the AddressBook.  
 `updateContact` (contact, callback) - where contact is an object with a valid recordID  
 `deleteContact` (contact, callback) - where contact is an object with a valid recordID  
@@ -76,6 +78,32 @@ Contacts.getAll((err, contacts) => {
 ```
 **NOTE**
 * on Android the entire display name is passed in the `givenName` field. `middleName` and `familyName` will be `""`.
+
+## getContactByPhoneNumber
+
+```js
+function lookupContact(phoneNumber, onSuccess, onFailure) {
+    if (!phoneNumber || phoneNumber == '') {
+        onFailure(new Error('phone number is empty'))
+        return
+    }
+    Contacts.getContactByPhoneNumber(phoneNumber, (err, contact) => {
+        if (err) {
+            onFailure(err)
+            return
+        }
+        onSuccess(contact)
+    })
+}
+```
+
+`contact` object
+
+```
+{
+  displayName: "The contact name found"
+}
+```
 
 ## Adding Contacts
 Currently all fields from the contact record except for thumbnailPath are supported for writing

--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
@@ -18,6 +18,7 @@ import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableArray;
+import com.facebook.react.bridge.WritableMap;
 
 import java.util.ArrayList;
 
@@ -82,6 +83,25 @@ public class ContactsManager extends ReactContextBaseJavaModule {
                 String photoUri = contactsProvider.getPhotoUriFromContactId(contactId);
 
                 callback.invoke(null, photoUri);
+            }
+        });
+    }
+
+    /*
+     * Returns contact details for a specific phone number
+     */
+    @ReactMethod
+    public void getContactByPhoneNumber(final String phoneNumber, final Callback callback) {
+        AsyncTask.execute(new Runnable() {
+            @Override
+            public void run() {
+                Context context = getReactApplicationContext();
+                ContentResolver cr = context.getContentResolver();
+
+                ContactsProvider contactsProvider = new ContactsProvider(cr, context);
+                WritableMap contact = contactsProvider.getContactByPhoneNumber(phoneNumber);
+
+                callback.invoke(null, contact);
             }
         });
     }

--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsProvider.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsProvider.java
@@ -26,6 +26,7 @@ import static android.provider.ContactsContract.CommonDataKinds.StructuredPostal
 public class ContactsProvider {
     public static final int ID_FOR_PROFILE_CONTACT = -1;
 
+
     private static final List<String> JUST_ME_PROJECTION = new ArrayList<String>() {{
         add(ContactsContract.RawContacts.SOURCE_ID);
         add(ContactsContract.Data.LOOKUP_KEY);
@@ -119,6 +120,32 @@ public class ContactsProvider {
         }
 
         return contacts;
+    }
+
+    public WritableMap getContactByPhoneNumber(String phoneNumber) {
+
+        WritableMap contactFound = Arguments.createMap();
+        Uri uri = Uri.withAppendedPath(ContactsContract.PhoneLookup.CONTENT_FILTER_URI, Uri.encode(phoneNumber));
+
+        String[] projection = new String[] {ContactsContract.PhoneLookup.DISPLAY_NAME};
+        Cursor cursor = this.contentResolver.query(uri, projection, null, null, null);
+        if (cursor == null) {
+            return null;
+        }
+
+        try {
+            if (cursor.moveToFirst()) {
+                String name = cursor.getString(cursor.getColumnIndex(ContactsContract.PhoneLookup.DISPLAY_NAME));
+                contactFound.putString("displayName", name);
+            }
+        } catch(Exception ex) {
+            Log.e("RNContacts", ex.getMessage());
+        } finally {
+            if (cursor != null && !cursor.isClosed()) {
+                cursor.close();
+            }
+        }
+        return contactFound;
     }
 
     @NonNull


### PR DESCRIPTION
- lookup for a phone number in the AddressBook
- implemented only on Android

Notes:
My app needs to lookup many phone numbers in the contact list in different screens, so initially I thought it was a good idea to lookup for each individually from the Andorid contacts DB.
The method looks for a phone number up and return a `displayName`.
Eventually I didn't end up using it because the async way this works would not have worked nicely with my app storage. Instead of looking at individual numbers just in time I store a map of phone_number => display_name when I use `getAll()` so it is available in the app synchronously to all screens.

Since I wrote the code anyway I thought I would open a PR and let the maintainer decide if it is useful.