### PR TITLE
Added support for all new fields to getAll()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # React Native Contacts
 Rx support with [react-native-contacts-rx](https://github.com/JeanLebrument/react-native-contacts-rx)
 
@@ -10,7 +11,7 @@ Rx support with [react-native-contacts-rx](https://github.com/JeanLebrument/reac
 | `getAll`  | ✔   | ✔ |
 | `addContact` | ✔ | ✔ |
 | `updateContact` | ✔ | ✔ |
-| `deleteContact` | ✔ | 😞 |
+| `deleteContact` | ✔ | ✔ |
 | get with options | 😞 | 😞 |
 | groups  | 😞 | 😞 |
 
@@ -25,6 +26,161 @@ Rx support with [react-native-contacts-rx](https://github.com/JeanLebrument/reac
 `deleteContact` (contact, callback) - where contact is an object with a valid recordID  
 `checkPermission` (callback) - checks permission to access Contacts  
 `requestPermission` (callback) - request permission to access Contacts
+
+## contact object
+The following contact fields are supported on iOS and Android. Where a field label is indicated, the Contact field populates the native field with as the label.
+
+| Key Name   | Value Type | iOS* | Android | Description |
+|------------|------------|------|---------|-------------|
+| recordID   | Integer    | R  | R     | Native contact manger record ID for this contact. Returned by getAll() and used to indicate contact record for updateContact(). Ignored by addContact(). Value is native platform dependent.
+| familyName | String     | R/W  | R/W     | Family name or "last name"
+| givenName  | String     | R/W  | R/W     | Given name or "first name"
+| middleName | String     | R/W  | R/W     | Middle name or names
+| nickName   | String     | R/W     | R/W     | Contact's nickname
+| phoneticFamilyName | String | R/W | R/W | Phonetic representation of familyName
+| phoneticMiddleName | String | R/W | R/W | Phonetic representation of middleName
+| phoneticGivenName | String | R/W  | R/W | Phonetic representation of givenName
+| company    | String     | R/W  | R/W     | Where the Contact works
+| jobTitle   | String     | R/W  | R/W     | Contact's job title
+| phoneNumbers | Array    | R/W  | R/W     | see [phoneNumbers](#phonenumbers)
+| emailAddresses | Array  | R/W  | R/W     | see [emailAddresses](#emailaddresses)
+| websites   | Array      | R/W  | R/W     | see [websites](#websites)
+| postalAddresses| Array  | R/W  | R/W     | see [postalAddresses](#postaladdresses)
+| note       | String     | R/W  | R/W     | Note about contact. Appears in "Notes" on native Contact Manager
+| birthday   | Object     | R/W    | R/W     | The contact's birthday, with or without year, as ```{ year: int, month: int, day: int }```[1]
+| thumbnailPath | String  | R/W  | R/W     | A 'file://' URL pointing to the contact's thumbnail image on the native device filesystem. See [Notes on adding and updating thumbnailPath](#notes-on-adding-and-updatring-thumbnailPath)
+
+
+[1] Android: Not all contact managers show birthday, however value can be written, read, and synced
+
+#### phoneNumbers
+
+An array of Objects containing phone numbers with the following key names:
+
+| Key Name   | Value Type | Description |
+|------------|------------|-------------|
+| label      | String     | One of: *home, work, mobile, fax, other*. An unrecognzied label will be added as 'other'|
+| number     | String     | A String containing the phone number associated with *label*
+| primary    | boolean    | Default = *false* *(WIP) Indicates this number is the Contact's primary number. If more than one phone number is provided to addContact() in the array, and none or more than one have primary set to *true*, the number added as the primary contact number is undefined
+
+
+#### emailAddresses
+
+An array of Objects containing email addresses with the following key names:
+
+| Key Name   | Value Type | Description |
+|------------|------------|-------------|
+| label      | String     | One of: *home, work, mobile, other*. An unrecognzied label will be added as 'other'|
+| email      | String     | A String containing the email address associated with *label*
+| primary    | boolean    | Default = *false* *(WIP) Indicates this email address is the Contact's primary email address. If more than one email address is provided to addContact() in the array, and none or more than one have primary set to *true*, the address added as the primary contact email address is undefined
+
+
+#### websites
+
+An array of Objects containing phone numbers with the following key names:
+
+| Key Name   | Value Type | Description |
+|------------|------------|-------------|
+| label      | String     | One of: *home, work, homepage, profile, blog, other*. An unrecognzied label will be added as 'other'|
+| url     | String     | A String containing the URL associated with *label*
+
+#### postalAddresses
+
+An array of Objects containing postal (physical) addresses with the following key names:
+
+| Key Name   | Value Type | Description |
+|------------|------------|-------------|
+| label      | String     | One of: *home, work, other*. An unrecognzied label will be added as 'other'|
+| street     | String     | The complete street address ("123 N. Main Street Suite 500") associated with *label*
+| city       | String     | The city in which the address resides.
+| region     | String     | A location designation between *city* and *country*, if customary or necessary. For addresses in the USA this is the "state", in Canada the "province", etc. *Platform note: Maps to "REGION" on Android and "STATE" on iOS.*
+| country    | String     | The *ISO 3166-1 ALPHA-2* country code. (Multilingual JSON files can be found at https://github.com/umpirsky/country-list)
+| postcode   | String     | The postal code (zip code) for this address.
+| primary    | boolean    | Default = *false* *(WIP) Indicates this postal address is the Contact's primary postal address. If more than one postal address is provided to addContact() in the array, and none or more than one have primary set to *true*, the address added as the primary postal address is undefined
+
+#### socialServices
+
+** IMPLEMENTATION PENDING **
+
+An array of Objects containing social media accounts for the contact with the following key names. All keys except "serviceId" are optional.
+
+Android implementation notes: As of API 25, the native contact manager only supports IM services, not social media services.
+
+| Key Name   | Value Type | Description |
+|------------|------------|-------------|
+| serviceId  | String     | A label indicating the social media service. iOS currently supports: "facebook", "flickr", linkedin", "myspace", sinaweibo", tencentweibo", "twitter", "yelp", and "gamecenter", and "custom".
+| serviceName | String | When serviceId is "custom", a string that represents the name of the service for use in user interfaces.
+| url | String | A URL associated with the social profile
+| uid | String | The user ID for this contact on this service
+| name | String | The name of this user on this service
+
+
+#### Notes on Adding and Updating thumbnailPath
+
+When calling addContact():
+
+>Should be the full size image for the contact in jpeg format. If the image is high-resoltuion, a low-resolution thumbnail will automatically be generated to be used in conjunction with the contact image.
+
+When calling updateContact():
+
+>If you are updating a contact retrieved from getAll(), remove thumbnailPath from your contact object if the photo should not be updated. The API can not determine if the current profile photo and thumbnailPath are the same and will always copy the thumbnailPath image (which is slow)
+
+
+## Example Contact Record
+```js
+{
+  recordID: 1,
+
+  familyName: "Jung",
+  givenName: "Carl",
+  middleName: "C.",
+  nickName: "Carl-o",
+  phoenticGivenName: "CAR-el",
+  phoneticFamilyName: "YUH-ng",
+
+  company: "Foomatics, Inc.",
+  jobTitle: "Developer",
+
+  phoneNumbers: [
+    {
+      label: "mobile",
+      number: "(555) 555-5555",
+      primary: true,
+    },{
+      label: "work",
+      number: "(555) 555-5556",
+    }
+  ],
+
+  emailAddresses: [{
+    label: "work",
+    email: "carl-jung@example.com",
+  }],
+
+  websites: [{
+    label: "homepage",
+    url: "http://www.carljung.com/",
+  }],
+
+  postalAddresses: [{
+    label: "work",
+    street: "123 N Main Street",
+    city: "Chicago",
+    region: "IL", //Illinois in USA
+    postcode: "12345-A234",
+    country: "US",
+  }],
+
+  note: "This is a note",
+
+  birthday: {
+      month: 6,
+      day: 12,
+  },
+
+  thumbnailPath: "file:///device/path/to/image.jpg",
+}
+```
 
 ## Usage
 `getAll` is a database intensive process, and can take a long time to complete depending on the size of the contacts list. Because of this, it is recommended you access the `getAll` method before it is needed, and cache the results for future use.
@@ -42,40 +198,6 @@ Contacts.getAll((err, contacts) => {
   }
 })
 ```
-
-## Example Contact Record
-```js
-{
-  recordID: '6b2237ee0df85980',
-  company: "",
-  emailAddresses: [{
-    label: "work",
-    email: "carl-jung@example.com",
-  }],
-  familyName: "Jung",
-  givenName: "Carl",
-  jobTitle: "",
-  middleName: "",
-  phoneNumbers: [{
-    label: "mobile",
-    number: "(555) 555-5555",
-  }],
-  thumbnailPath: 'content://com.android.contacts/display_photo/3',
-  postalAddresses: 
-    [ 
-      {
-        postCode: 'Postcooode',
-        city: 'City',
-        neighborhood: 'neighborhood',
-        street: 'Home Street',
-        formattedAddress: 'Home Street\nneighborhood\nCity Postcooode',
-        label: 'work' 
-      }
-    ]
-}
-```
-**NOTE**
-* on Android the entire display name is passed in the `givenName` field. `middleName` and `familyName` will be `""`.
 
 ## Adding Contacts
 Currently all fields from the contact record except for thumbnailPath are supported for writing
@@ -162,7 +284,7 @@ dependencies {
 
 	public class MainApplication extends Application implements ReactApplication {
 	    ...
-		
+
 	    @Override
 	    protected List<ReactPackage> getPackages() {
 	      return Arrays.<ReactPackage>asList(

--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsProvider.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsProvider.java
@@ -18,10 +18,18 @@ import java.util.Map;
 
 import static android.provider.ContactsContract.CommonDataKinds.Contactables;
 import static android.provider.ContactsContract.CommonDataKinds.Email;
+import static android.provider.ContactsContract.CommonDataKinds.Event;
+import static android.provider.ContactsContract.CommonDataKinds.Nickname;
+import static android.provider.ContactsContract.CommonDataKinds.Note;
 import static android.provider.ContactsContract.CommonDataKinds.Organization;
 import static android.provider.ContactsContract.CommonDataKinds.Phone;
 import static android.provider.ContactsContract.CommonDataKinds.StructuredName;
+import static android.provider.ContactsContract.CommonDataKinds.Organization;
 import static android.provider.ContactsContract.CommonDataKinds.StructuredPostal;
+import static android.provider.ContactsContract.CommonDataKinds.Website;
+import static android.provider.ContactsContract.CommonDataKinds.Note;
+import static android.provider.ContactsContract.CommonDataKinds.Event;
+import static android.provider.ContactsContract.CommonDataKinds.Nickname;
 
 public class ContactsProvider {
     public static final int ID_FOR_PROFILE_CONTACT = -1;
@@ -36,6 +44,9 @@ public class ContactsProvider {
         add(StructuredName.GIVEN_NAME);
         add(StructuredName.MIDDLE_NAME);
         add(StructuredName.FAMILY_NAME);
+        add(StructuredName.PHONETIC_GIVEN_NAME);
+        add(StructuredName.PHONETIC_MIDDLE_NAME);
+        add(StructuredName.PHONETIC_FAMILY_NAME);
         add(Phone.NUMBER);
         add(Phone.TYPE);
         add(Phone.LABEL);
@@ -43,18 +54,20 @@ public class ContactsProvider {
         add(Email.ADDRESS);
         add(Email.TYPE);
         add(Email.LABEL);
-        add(Organization.COMPANY);
-        add(Organization.TITLE);
-        add(StructuredPostal.FORMATTED_ADDRESS);
         add(StructuredPostal.TYPE);
-        add(StructuredPostal.LABEL);
         add(StructuredPostal.STREET);
-        add(StructuredPostal.POBOX);
-        add(StructuredPostal.NEIGHBORHOOD);
         add(StructuredPostal.CITY);
         add(StructuredPostal.REGION);
         add(StructuredPostal.POSTCODE);
         add(StructuredPostal.COUNTRY);
+        add(Organization.COMPANY);
+        add(Organization.TITLE);
+        add(Website.URL);
+        add(Website.TYPE);
+        add(Note.NOTE);
+        add(Event.TYPE);
+        add(Event.START_DATE);
+        add(Nickname.NAME);
     }};
 
     private static final List<String> FULL_PROJECTION = new ArrayList<String>() {{
@@ -96,8 +109,26 @@ public class ContactsProvider {
             Cursor cursor = contentResolver.query(
                     ContactsContract.Data.CONTENT_URI,
                     FULL_PROJECTION.toArray(new String[FULL_PROJECTION.size()]),
-                    ContactsContract.Data.MIMETYPE + "=? OR " + ContactsContract.Data.MIMETYPE + "=? OR " + ContactsContract.Data.MIMETYPE + "=? OR " + ContactsContract.Data.MIMETYPE + "=? OR " + ContactsContract.Data.MIMETYPE + "=?",
-                    new String[]{Email.CONTENT_ITEM_TYPE, Phone.CONTENT_ITEM_TYPE, StructuredName.CONTENT_ITEM_TYPE, Organization.CONTENT_ITEM_TYPE, StructuredPostal.CONTENT_ITEM_TYPE},
+                    ContactsContract.Data.MIMETYPE + "=? OR "
+                    + ContactsContract.Data.MIMETYPE + "=? OR "
+                    + ContactsContract.Data.MIMETYPE + "=? OR "
+                    + ContactsContract.Data.MIMETYPE + "=? OR "
+                    + ContactsContract.Data.MIMETYPE + "=? OR "
+                    + ContactsContract.Data.MIMETYPE + "=? OR "
+                    + ContactsContract.Data.MIMETYPE + "=? OR "
+                    + ContactsContract.Data.MIMETYPE + "=? OR "
+                    + ContactsContract.Data.MIMETYPE + "=?",
+                    new String[]{
+                        Email.CONTENT_ITEM_TYPE,
+                        Phone.CONTENT_ITEM_TYPE,
+                        StructuredName.CONTENT_ITEM_TYPE,
+                        StructuredPostal.CONTENT_ITEM_TYPE,
+                        Organization.CONTENT_ITEM_TYPE,
+                        Website.CONTENT_ITEM_TYPE,
+                        Note.CONTENT_ITEM_TYPE,
+                        Event.CONTENT_ITEM_TYPE,
+                        Nickname.CONTENT_ITEM_TYPE
+                      },
                     null
             );
 
@@ -151,18 +182,18 @@ public class ContactsProvider {
                 contact.displayName = name;
             }
 
-            if(TextUtils.isEmpty(contact.photoUri)) {
-                String rawPhotoURI = cursor.getString(cursor.getColumnIndex(Contactables.PHOTO_URI));
-                if (!TextUtils.isEmpty(rawPhotoURI)) {
-                    contact.photoUri = rawPhotoURI;
-                    contact.hasPhoto = true;
-                }
+            String rawPhotoURI = cursor.getString(cursor.getColumnIndex(Contactables.PHOTO_URI));
+            if (!TextUtils.isEmpty(rawPhotoURI) && TextUtils.isEmpty(contact.photoUri)) {
+                contact.photoUri = getPhotoURIFromContactURI(rawPhotoURI, contactId);
             }
 
             if (mimeType.equals(StructuredName.CONTENT_ITEM_TYPE)) {
-                contact.givenName = cursor.getString(cursor.getColumnIndex(StructuredName.GIVEN_NAME));
+                contact.givenName  = cursor.getString(cursor.getColumnIndex(StructuredName.GIVEN_NAME));
                 contact.middleName = cursor.getString(cursor.getColumnIndex(StructuredName.MIDDLE_NAME));
                 contact.familyName = cursor.getString(cursor.getColumnIndex(StructuredName.FAMILY_NAME));
+                contact.phoneticGivenName  = cursor.getString(cursor.getColumnIndex(StructuredName.PHONETIC_GIVEN_NAME));
+                contact.phoneticMiddleName = cursor.getString(cursor.getColumnIndex(StructuredName.PHONETIC_MIDDLE_NAME));
+                contact.phoneticFamilyName = cursor.getString(cursor.getColumnIndex(StructuredName.PHONETIC_FAMILY_NAME));
             } else if (mimeType.equals(Phone.CONTENT_ITEM_TYPE)) {
                 String phoneNumber = cursor.getString(cursor.getColumnIndex(Phone.NUMBER));
                 int type = cursor.getInt(cursor.getColumnIndex(Phone.TYPE));
@@ -212,12 +243,74 @@ public class ContactsProvider {
                     }
                     contact.emails.add(new Contact.Item(label, email));
                 }
+            } else if (mimeType.equals(StructuredPostal.CONTENT_ITEM_TYPE)) {
+                Contact.PostalAddress address = new Contact.PostalAddress();
+                address.street   = cursor.getString(cursor.getColumnIndex(StructuredPostal.STREET));
+                address.city     = cursor.getString(cursor.getColumnIndex(StructuredPostal.CITY));
+                address.region   = cursor.getString(cursor.getColumnIndex(StructuredPostal.REGION));
+                address.postcode = cursor.getString(cursor.getColumnIndex(StructuredPostal.POSTCODE));
+                address.country  = cursor.getString(cursor.getColumnIndex(StructuredPostal.COUNTRY));
+
+                int type = cursor.getInt(cursor.getColumnIndex(StructuredPostal.TYPE));
+
+                String label;
+                switch (type) {
+                    case StructuredPostal.TYPE_HOME:
+                        label = "home";
+                        break;
+                    case StructuredPostal.TYPE_WORK:
+                        label = "work";
+                        break;
+                    default:
+                        label = "other";
+                }
+                address.label = label;
+                contact.postalAddresses.add(address);
+            } else if (mimeType.equals(Website.CONTENT_ITEM_TYPE)) {
+                String url = cursor.getString(cursor.getColumnIndex(Website.URL));
+                int type = cursor.getInt(cursor.getColumnIndex(Website.TYPE));
+
+                if (!TextUtils.isEmpty(url)) {
+                    String label;
+                    switch (type) {
+                        case Website.TYPE_HOMEPAGE:
+                            label = "hompagee";
+                            break;
+                        case Website.TYPE_BLOG:
+                            label = "blog";
+                            break;
+                        case Website.TYPE_PROFILE:
+                            label = "profile";
+                            break;
+                        case Website.TYPE_HOME:
+                            label = "home";
+                            break;
+                        case Website.TYPE_WORK:
+                            label = "work";
+                            break;
+                        case Website.TYPE_CUSTOM:
+                            if (cursor.getString(cursor.getColumnIndex(Website.LABEL)) != null) {
+                                label = cursor.getString(cursor.getColumnIndex(Website.LABEL)).toLowerCase();
+                            } else {
+                                label = "";
+                            }
+                            break;
+                        default:
+                            label = "other";
+                    }
+                    contact.websites.add(new Contact.Item(label, url));
+                }
             } else if (mimeType.equals(Organization.CONTENT_ITEM_TYPE)) {
                 contact.company = cursor.getString(cursor.getColumnIndex(Organization.COMPANY));
                 contact.jobTitle = cursor.getString(cursor.getColumnIndex(Organization.TITLE));
-            } else if (mimeType.equals(StructuredPostal.CONTENT_ITEM_TYPE)) {
-                contact.postalAddresses.add(new Contact.PostalAddressItem(cursor));
+            } else if (mimeType.equals(Note.CONTENT_ITEM_TYPE)) {
+                contact.note = cursor.getString(cursor.getColumnIndex(Note.NOTE));
+            } else if (mimeType.equals(Event.CONTENT_ITEM_TYPE)) {
+                contact.birthday.setDate("birthday",cursor.getString(cursor.getColumnIndex(Event.START_DATE)));
+            } else if (mimeType.equals(Nickname.CONTENT_ITEM_TYPE)) {
+                contact.nickName = cursor.getString(cursor.getColumnIndex(Nickname.NAME));
             }
+
         }
 
         return map;
@@ -252,13 +345,19 @@ public class ContactsProvider {
         private String givenName = "";
         private String middleName = "";
         private String familyName = "";
+        private String phoneticGivenName = "";
+        private String phoneticMiddleName = "";
+        private String phoneticFamilyName = "";
+        private String nickName = "";
         private String company = "";
         private String jobTitle ="";
-        private boolean hasPhoto = false;
+        private String note = "";
         private String photoUri;
         private List<Item> emails = new ArrayList<>();
         private List<Item> phones = new ArrayList<>();
-        private List<PostalAddressItem> postalAddresses = new ArrayList<>();
+        private List<Item> websites = new ArrayList<>();
+        private List<PostalAddress> postalAddresses = new ArrayList<>();
+        private SimpleDate birthday = new SimpleDate();
 
         public Contact(String contactId) {
             this.contactId = contactId;
@@ -270,9 +369,14 @@ public class ContactsProvider {
             contact.putString("givenName", TextUtils.isEmpty(givenName) ? displayName : givenName);
             contact.putString("middleName", middleName);
             contact.putString("familyName", familyName);
+            contact.putString("phoneticGivenName", phoneticGivenName);
+            contact.putString("phoneticMiddleName", phoneticMiddleName);
+            contact.putString("phoneticFamilyName", phoneticFamilyName);
+            contact.putString("nickName", nickName);
+
             contact.putString("company", company);
             contact.putString("jobTitle", jobTitle);
-            contact.putBoolean("hasThumbnail", this.hasPhoto);
+            contact.putString("note", note);
             contact.putString("thumbnailPath", photoUri == null ? "" : photoUri);
 
             WritableArray phoneNumbers = Arguments.createArray();
@@ -293,12 +397,36 @@ public class ContactsProvider {
             }
             contact.putArray("emailAddresses", emailAddresses);
 
-            WritableArray postalAddresses = Arguments.createArray();
-            for (PostalAddressItem item : this.postalAddresses) {
-              postalAddresses.pushMap(item.map);
+            WritableArray websitesArray = Arguments.createArray();
+            for (Item item : websites) {
+                WritableMap map = Arguments.createMap();
+                map.putString("url", item.value);
+                map.putString("label", item.label);
+                websitesArray.pushMap(map);
             }
-            contact.putArray("postalAddresses", postalAddresses);
+            contact.putArray("websites", websitesArray);
 
+            //TODO: postal addresses
+            WritableArray postalArray = Arguments.createArray();
+            for (PostalAddress address : postalAddresses) {
+                WritableMap map = Arguments.createMap();
+                map.putString("label", address.label);
+                map.putString("street", address.street);
+                map.putString("city", address.city);
+                map.putString("region", address.region);
+                map.putString("country", address.country);
+                map.putString("postcode", address.postcode);
+                postalArray.pushMap(map);
+            }
+            contact.putArray("postalAddresses", postalArray);
+
+            if(this.birthday != null ) {
+                WritableMap map = Arguments.createMap();
+                map.putInt("year",this.birthday.year);
+                map.putInt("month",this.birthday.month);
+                map.putInt("day",this.birthday.day);
+                contact.putMap("birthday",map);
+            }
             return contact;
         }
 
@@ -312,41 +440,43 @@ public class ContactsProvider {
             }
         }
 
-        public static class PostalAddressItem {
-            public final WritableMap map;
+        public static class SimpleDate {
+            public int year;
+            public int month;
+            public int day;
+            public String label;
 
-            public PostalAddressItem(Cursor cursor) {
-                map = Arguments.createMap();
+            public void setDate(String label, String androidDateString) {
+                String[] vals = androidDateString.split("-");
+                int idx = 0;
+                if (androidDateString.startsWith("--")) idx = 1; // no year in date
+                this.label = label;
 
-                map.putString("label", getLabel(cursor));
-                putString(cursor, "formattedAddress", StructuredPostal.FORMATTED_ADDRESS);
-                putString(cursor, "street", StructuredPostal.STREET);
-                putString(cursor, "pobox", StructuredPostal.POBOX);
-                putString(cursor, "neighborhood", StructuredPostal.NEIGHBORHOOD);
-                putString(cursor, "city", StructuredPostal.CITY);
-                putString(cursor, "region", StructuredPostal.REGION);
-                putString(cursor, "postCode", StructuredPostal.POSTCODE);
-                putString(cursor, "country", StructuredPostal.COUNTRY);
-            }
-
-            private void putString(Cursor cursor, String key, String androidKey) {
-                final String value = cursor.getString(cursor.getColumnIndex(androidKey));
-                if (!TextUtils.isEmpty(value))
-                  map.putString(key, value);
-            }
-
-            static String getLabel(Cursor cursor) {
-                switch (cursor.getInt(cursor.getColumnIndex(StructuredPostal.TYPE))) {
-                    case StructuredPostal.TYPE_HOME:
-                        return "home";
-                    case StructuredPostal.TYPE_WORK:
-                        return "work";
-                    case StructuredPostal.TYPE_CUSTOM:
-                        final String label = cursor.getString(cursor.getColumnIndex(StructuredPostal.LABEL));
-                        return label != null ? label : "";
+                try {
+                  if(!TextUtils.isEmpty(vals[idx])) this.year  = Integer.parseInt(vals[idx]);
+                  idx++;
+                  if(!TextUtils.isEmpty(vals[idx])) this.month = Integer.parseInt(vals[idx]);
+                  idx++;
+                  if(!TextUtils.isEmpty(vals[idx])) this.day   = Integer.parseInt(vals[idx]);
+                } catch (Exception e) {
+                  Log.e("ContactsProvider: date tokenize failed:",e.toString());
                 }
-                return "other";
             }
+
+            public SimpleDate() {
+                this.label = "";
+                this.year = this.month = this.day = 0;
+            }
+
+        }
+
+        public static class PostalAddress {
+            public String label;
+            public String street;
+            public String city;
+            public String region;
+            public String country;
+            public String postcode;
         }
     }
 }

--- a/ios/RCTContacts/RCTContacts.m
+++ b/ios/RCTContacts/RCTContacts.m
@@ -1,6 +1,7 @@
 #import <AddressBook/AddressBook.h>
 #import <UIKit/UIKit.h>
 #import "RCTContacts.h"
+#import "RCTLog.h"
 
 @implementation RCTContacts
 
@@ -101,8 +102,6 @@ RCT_EXPORT_METHOD(getAllWithoutPhotos:(RCTResponseSenderBlock) callback)
   NSString *givenName = (__bridge_transfer NSString *)(ABRecordCopyValue(person, kABPersonFirstNameProperty));
   NSString *familyName = (__bridge_transfer NSString *)(ABRecordCopyValue(person, kABPersonLastNameProperty));
   NSString *middleName = (__bridge_transfer NSString *)(ABRecordCopyValue(person, kABPersonMiddleNameProperty));
-  NSString *company = (__bridge_transfer NSString *)(ABRecordCopyValue(person, kABPersonOrganizationProperty));
-  NSString *jobTitle = (__bridge_transfer NSString *)(ABRecordCopyValue(person, kABPersonJobTitleProperty));
 
   [contact setObject: recordID forKey: @"recordID"];
 
@@ -119,14 +118,6 @@ RCT_EXPORT_METHOD(getAllWithoutPhotos:(RCTResponseSenderBlock) callback)
 
   if(middleName){
     [contact setObject: (middleName) ? middleName : @"" forKey:@"middleName"];
-  }
-
-  if(company){
-    [contact setObject: (company) ? company : @"" forKey:@"company"];
-  }
-
-  if(jobTitle){
-    [contact setObject: (jobTitle) ? jobTitle : @"" forKey:@"jobTitle"];
   }
 
   if(!hasName){
@@ -160,7 +151,6 @@ RCT_EXPORT_METHOD(getAllWithoutPhotos:(RCTResponseSenderBlock) callback)
 
   //handle emails
   NSMutableArray *emailAddreses = [[NSMutableArray alloc] init];
-
   ABMultiValueRef multiEmails = ABRecordCopyValue(person, kABPersonEmailProperty);
   for(CFIndex i=0;i<ABMultiValueGetCount(multiEmails);i++) {
     CFStringRef emailAddressRef = ABMultiValueCopyValueAtIndex(multiEmails, i);
@@ -178,53 +168,92 @@ RCT_EXPORT_METHOD(getAllWithoutPhotos:(RCTResponseSenderBlock) callback)
     [email setObject: emailLabel forKey:@"label"];
     [emailAddreses addObject:email];
   }
-  //end emails
-
   [contact setObject: emailAddreses forKey:@"emailAddresses"];
+  //end emails
+  
+  [contact setObject: [self getABPersonThumbnailFilepath:person] forKey:@"thumbnailPath"];
 
+  //handle birthday from contacts//
+  CFDateRef birthDate = ABRecordCopyValue(person, kABPersonBirthdayProperty);
+  NSDateFormatter *dateFormatter = nil;
+  if(birthDate)
+  {
+    if (dateFormatter == nil) {
+      dateFormatter = [[NSDateFormatter alloc] init];
+      [dateFormatter setTimeStyle:NSDateFormatterMediumStyle];
+      [dateFormatter setDateStyle:NSDateFormatterMediumStyle];
+    }
+    NSString* strBirthday = [dateFormatter stringFromDate:(__bridge_transfer NSDate *)birthDate ];
+    [contact setObject: strBirthday forKey:@"birthday"];
+  }
+  CFRelease(birthDate);
+  ///////////////////////////////////
+
+  //handle websites
+  NSMutableArray *websites = [[NSMutableArray alloc] init];
+  ABMultiValueRef multiUrls = ABRecordCopyValue(person, kABPersonURLProperty);
+  for(CFIndex i=0;i<ABMultiValueGetCount(multiUrls);i++) {
+    CFStringRef urlAddressRef = ABMultiValueCopyValueAtIndex(multiUrls, i);
+    CFStringRef urlLabelRef = ABMultiValueCopyLabelAtIndex(multiUrls, i);
+    NSString *urlAddress = (__bridge_transfer NSString *) urlAddressRef;
+    NSString *urlLabel = (__bridge_transfer NSString *) ABAddressBookCopyLocalizedLabel(urlLabelRef);
+    if(urlAddressRef){
+      CFRelease(urlAddressRef);
+    }
+    if(urlLabelRef){
+      CFRelease(urlLabelRef);
+    }
+    NSMutableDictionary* url = [NSMutableDictionary dictionary];
+    [url setObject: urlAddress forKey:@"url"];
+    [url setObject: urlLabel forKey:@"label"];
+    [websites addObject:url];
+  }
+  [contact setObject: websites forKey:@"websites"];
+  //end websites
+  
+  //handle postalAddresses
   NSMutableArray *postalAddresses = [[NSMutableArray alloc] init];
-  ABMultiValueRef multiPostalAddresses = ABRecordCopyValue(person, kABPersonAddressProperty);
-  for(CFIndex i=0;i<ABMultiValueGetCount(multiPostalAddresses);i++) {
+  ABMultiValueRef multiAddresses = ABRecordCopyValue(person, kABPersonAddressProperty);
+  for(CFIndex i=0;i<ABMultiValueGetCount(multiAddresses);i++) {
+    CFStringRef addrLabelRef = ABMultiValueCopyLabelAtIndex(multiAddresses, i);
+    NSString *addrLabel = (__bridge_transfer NSString *) ABAddressBookCopyLocalizedLabel(addrLabelRef);
+    if(addrLabelRef){
+      CFRelease(addrLabelRef);
+    }
+    CFDictionaryRef dict = ABMultiValueCopyValueAtIndex(multiAddresses, i);
+    NSString * street = CFDictionaryGetValue(dict, kABPersonAddressStreetKey);
+    NSString * city = CFDictionaryGetValue(dict, kABPersonAddressCityKey);
+    NSString * region = CFDictionaryGetValue(dict, kABPersonAddressStateKey);
+    NSString * postcode = CFDictionaryGetValue(dict, kABPersonAddressZIPKey);
+    NSString * country = CFDictionaryGetValue(dict, kABPersonAddressCountryKey);
     NSMutableDictionary* address = [NSMutableDictionary dictionary];
-
-    NSDictionary *addressDict = (__bridge NSDictionary *)ABMultiValueCopyValueAtIndex(multiPostalAddresses, i);
-    NSString* street = [addressDict objectForKey:(NSString*)kABPersonAddressStreetKey];
-    if(street){
-      [address setObject:street forKey:@"street"];
-    }
-    NSString* city = [addressDict objectForKey:(NSString*)kABPersonAddressCityKey];
-    if(city){
-      [address setObject:city forKey:@"city"];
-    }
-    NSString* region = [addressDict objectForKey:(NSString*)kABPersonAddressStateKey];
-    if(region){
-      [address setObject:region forKey:@"region"];
-    }
-    NSString* postCode = [addressDict objectForKey:(NSString*)kABPersonAddressZIPKey];
-    if(postCode){
-      [address setObject:postCode forKey:@"postCode"];
-    }
-    NSString* country = [addressDict objectForKey:(NSString*)kABPersonAddressCountryCodeKey];
-    if(country){
-      [address setObject:country forKey:@"country"];
-    }
-
-    CFStringRef addresssLabelRef = ABMultiValueCopyLabelAtIndex(multiPostalAddresses, i);
-    NSString *addressLabel = (__bridge_transfer NSString *) ABAddressBookCopyLocalizedLabel(addresssLabelRef);
-    if(addresssLabelRef){
-      CFRelease(addresssLabelRef);
-    }
-    [address setObject:addressLabel forKey:@"label"];
-
+    [address setObject: addrLabel forKey:@"label"];
+    [address setObject: street forKey:@"street"];
+    [address setObject: city forKey:@"city"];
+    [address setObject: region forKey:@"region"];
+    [address setObject: postcode forKey:@"postcode"];
+    [address setObject: country forKey:@"country"];
     [postalAddresses addObject:address];
   }
-  CFRelease(multiPostalAddresses);
-  [contact setObject:postalAddresses forKey:@"postalAddresses"];
-
-  [contact setValue:[NSNumber numberWithBool:ABPersonHasImageData(person)] forKey:@"hasThumbnail"];
-  if (withThumbnails) {
-    [contact setObject: [self getABPersonThumbnailFilepath:person] forKey:@"thumbnailPath"];
-  }
+  [contact setObject: postalAddresses forKey:@"postalAddresses"];
+  //end postalAddresses
+  
+  //handle note, nickName, phoneticGivenName, phoneticFamilyName, phoneticMiddleName, company, jobTitle//
+  NSString *note = (__bridge_transfer NSString *)(ABRecordCopyValue(person, kABPersonNoteProperty));
+  NSString *nickName = (__bridge_transfer NSString *)(ABRecordCopyValue(person, kABPersonNicknameProperty));
+  NSString *phoneticGivenName = (__bridge_transfer NSString *)(ABRecordCopyValue(person, kABPersonFirstNamePhoneticProperty));
+  NSString *phoneticFamilyName = (__bridge_transfer NSString *)(ABRecordCopyValue(person, kABPersonLastNamePhoneticProperty));
+  NSString *phoneticMiddleName = (__bridge_transfer NSString *)(ABRecordCopyValue(person, kABPersonMiddleNamePhoneticProperty));
+  NSString *company = (__bridge_transfer NSString *)(ABRecordCopyValue(person, kABPersonOrganizationProperty));
+  NSString *jobTitle = (__bridge_transfer NSString *)(ABRecordCopyValue(person, kABPersonJobTitleProperty));
+  if(note)               [contact setObject: note forKey:@"note"];
+  if(nickName)           [contact setObject: nickName forKey:@"nickName"];
+  if(phoneticGivenName)  [contact setObject: phoneticGivenName forKey:@"phoneticGivenName"];
+  if(phoneticFamilyName) [contact setObject: phoneticFamilyName forKey:@"phoneticFamilyName"];
+  if(phoneticMiddleName) [contact setObject: phoneticMiddleName forKey:@"phoneticMiddleName"];
+  if(company)            [contact setObject: company forKey:@"company"];
+  if(jobTitle)           [contact setObject: jobTitle forKey:@"jobTitle"];
+  ////////////
   return contact;
 }
 
@@ -312,13 +341,9 @@ RCT_EXPORT_METHOD(updateContact:(NSDictionary *)contactData callback:(RCTRespons
   NSString *givenName = [contactData valueForKey:@"givenName"];
   NSString *familyName = [contactData valueForKey:@"familyName"];
   NSString *middleName = [contactData valueForKey:@"middleName"];
-  NSString *company = [contactData valueForKey:@"company"];
-  NSString *jobTitle = [contactData valueForKey:@"jobTitle"];
   ABRecordSetValue(record, kABPersonFirstNameProperty, (__bridge CFStringRef) givenName, &error);
   ABRecordSetValue(record, kABPersonLastNameProperty, (__bridge CFStringRef) familyName, &error);
   ABRecordSetValue(record, kABPersonMiddleNameProperty, (__bridge CFStringRef) middleName, &error);
-  ABRecordSetValue(record, kABPersonOrganizationProperty, (__bridge CFStringRef) company, &error);
-  ABRecordSetValue(record, kABPersonJobTitleProperty, (__bridge CFStringRef) jobTitle, &error);
 
   ABMutableMultiValueRef multiPhone = ABMultiValueCreateMutable(kABMultiStringPropertyType);
   NSArray* phoneNumbers = [contactData valueForKey:@"phoneNumbers"];
@@ -352,8 +377,92 @@ RCT_EXPORT_METHOD(updateContact:(NSDictionary *)contactData callback:(RCTRespons
   }
   ABRecordSetValue(record, kABPersonEmailProperty, multiEmail, nil);
   CFRelease(multiEmail);
-
   ABAddressBookSave(addressBookRef, &error);
+ 
+  //Add Profile Image//
+  NSString *thumbnailPath = [contactData valueForKey:@"thumbnailPath"];
+  UIImage *img = [UIImage imageWithContentsOfFile:thumbnailPath];
+  NSData *dataRef = UIImagePNGRepresentation(img);
+  CFDataRef cfDataRef = CFDataCreate(NULL, [dataRef bytes], [dataRef length]);
+  ABPersonRemoveImageData(record, &error);
+  if (ABAddressBookSave(addressBookRef, &error))
+  {
+    ABPersonSetImageData(record, cfDataRef, &error);
+    ABAddressBookSave(addressBookRef, &error);
+  }
+  /////////////////////
+  
+  //Add Birthday//
+  id objBirthday = [contactData valueForKey:@"birthday"];
+  NSString *strMonth = [objBirthday valueForKey:@"month"];
+  NSString *strDay = [objBirthday valueForKey:@"day"];
+  strDay = [NSString stringWithFormat:@"%i", strDay.intValue + 1];
+  
+  NSDateFormatter* formatter = [[NSDateFormatter alloc] init];
+  [formatter setDateFormat:@"dd.MM.yyyy"];
+  NSDate *birthday = [formatter dateFromString:[NSString stringWithFormat:@"%@.%@.1604",strDay, strMonth]];
+  
+  ABRecordSetValue(record, kABPersonBirthdayProperty,(__bridge CFDateRef)birthday, &error);
+  ABAddressBookSave (addressBookRef,&error);
+  ////////////////
+  
+  //Add Website URLs//
+  ABMutableMultiValueRef multiURL = ABMultiValueCreateMutable(kABMultiStringPropertyType);
+  NSArray* urlArray = [contactData valueForKey:@"websites"];
+  for (id urlData in urlArray) {
+    NSString *label = [urlData valueForKey:@"label"];
+    NSString *url = [urlData valueForKey:@"url"];
+    
+    ABMultiValueAddValueAndLabel(multiURL, (__bridge CFStringRef) url, (__bridge CFStringRef) label, NULL);
+  }
+  ABRecordSetValue(record, kABPersonURLProperty, multiURL, nil);
+  CFRelease(multiURL);
+  ABAddressBookSave(addressBookRef, &error);
+  ////////////////////
+  
+  //Add Address//
+  ABMultiValueRef addresses = ABMultiValueCreateMutable(kABMultiDictionaryPropertyType);
+  NSArray* addressArray = [contactData valueForKey:@"postalAddresses"];
+  for (id addressData in addressArray) {
+    NSString *label = [addressData valueForKey:@"label"];
+    NSString *street = [addressData valueForKey:@"street"];
+    NSString *city = [addressData valueForKey:@"city"];
+    NSString *region = [addressData valueForKey:@"region"];
+    NSString *postcode = [addressData valueForKey:@"postcode"];
+    NSString *country = [addressData valueForKey:@"country"];
+    NSDictionary *values = [NSDictionary dictionaryWithObjectsAndKeys:
+                            street, (NSString *)kABPersonAddressStreetKey,
+                            city, (NSString *)kABPersonAddressCityKey,
+                            region, (NSString *)kABPersonAddressStateKey,
+                            postcode, (NSString *)kABPersonAddressZIPKey,
+                            country, (NSString *)kABPersonAddressCountryKey,
+                            nil];
+    ABMultiValueAddValueAndLabel(addresses, (__bridge CFDictionaryRef)values, (__bridge CFStringRef)(label), NULL);
+  }
+  ABRecordSetValue(record, kABPersonAddressProperty, addresses, &error);
+  CFRelease(addresses);
+  ABAddressBookSave(addressBookRef, &error);
+  ////////////////////
+  
+  //Add note, nickName, phoneticGivenName, phoneticFamilyName, phoneticMiddleName, company, jobTitle//
+  NSString *note = [contactData valueForKey:@"note"];
+  NSString *nickName = [contactData valueForKey:@"nickName"];
+  NSString *phoneticGivenName = [contactData valueForKey:@"phoneticGivenName"];
+  NSString *phoneticFamilyName = [contactData valueForKey:@"phoneticFamilyName"];
+  NSString *phoneticMiddleName = [contactData valueForKey:@"phoneticMiddleName"];
+  NSString *company = [contactData valueForKey:@"company"];
+  NSString *jobTitle = [contactData valueForKey:@"jobTitle"];
+  ABRecordSetValue(record, kABPersonNoteProperty, (__bridge CFStringRef) note, &error);
+  ABRecordSetValue(record, kABPersonNicknameProperty, (__bridge CFStringRef) nickName, &error);
+  ABRecordSetValue(record, kABPersonFirstNamePhoneticProperty, (__bridge CFStringRef) phoneticGivenName, &error);
+  ABRecordSetValue(record, kABPersonLastNamePhoneticProperty, (__bridge CFStringRef) phoneticFamilyName, &error);
+  ABRecordSetValue(record, kABPersonMiddleNamePhoneticProperty, (__bridge CFStringRef) phoneticMiddleName, &error);
+  ABRecordSetValue(record, kABPersonOrganizationProperty, (__bridge CFStringRef) company, &error);
+  ABRecordSetValue(record, kABPersonJobTitleProperty, (__bridge CFStringRef) jobTitle, &error);
+  ABAddressBookSave(addressBookRef, &error);
+  ////////////
+  
+  CFRelease(addressBookRef);
   if (error != NULL)
   {
     CFStringRef errorDesc = CFErrorCopyDescription(error);


### PR DESCRIPTION
Fixed bug in getAll() where thumbnailImage was copied for each contact item

Doc update

addContact:
   - Refactored and simplified key-value array attributes using a HashMap (email, phone)
   - Added support for adding: Website array, note, nickname, photo

Updated Readme
Comment update in ContactsManager.java

fix type-o

added missing company/job fields to docs

doc formatting change

Combine the internals of addContact() and updateContact() into a single private function with a switch to change between add and update. (TODO: Test update in all cases)

Docs update

fixed crashing as a result of no emails/websites/phone numbers

docs updated to incude fields I need for my app. Details may change as iOS version implemented, but fields supported likely wont.

Type-o and markdown fixes in docs

Doc fix\nAdded log message for testing

Addresses working on Android. TODO: Some android devices with non-Google contact manger don't immediately show the contact upon adding. Solution is get groups and add contact to a visible group. Need to code that, plus some way to check so we don't do it unless it's needed

Added support for adding Birthday and Phonetic Name.

Docs update

Docs update

added temp output for debugging

Remove debugging Log messages
Added support for all fields to getAll()
Fixed bug in getAll() where thumbnailImage was copied for each contact item

Doc update

iOS : profile image is added to address-book

Updated documentation for iOS updates

fixup docs

iOS : getAll() and addContact() works for all field of MeCard

@proberts something like this. Note I haven't tested it and I very likely messed something up. But I cannot accept a 25 commit PR. The git history for the project will become unfollowable. If necessary, rewrite this functionality in a single go.