### PR TITLE
ios: Update headers for RN 0.40.

### DIFF
--- a/ios/RCTContacts/RCTContacts.h
+++ b/ios/RCTContacts/RCTContacts.h
@@ -1,4 +1,4 @@
-#import "RCTBridgeModule.h"
+#import <React/RCTBridgeModule.h>
 
 @interface RCTContacts : NSObject <RCTBridgeModule>
 


### PR DESCRIPTION
In react-native 0.40 they moved ios headers to React namespace