### PR TITLE
3 ios improvements (please squash when merging)

### DIFF
--- a/ios/RCTContacts/RCTContacts.m
+++ b/ios/RCTContacts/RCTContacts.m
@@ -33,6 +33,10 @@ RCT_EXPORT_METHOD(checkPermission:(RCTResponseSenderBlock) callback)
 
 RCT_EXPORT_METHOD(requestPermission:(RCTResponseSenderBlock) callback)
 {
+    if(!contactStore) {
+        contactStore = [[CNContactStore alloc] init];
+    }
+
     [contactStore requestAccessForEntityType:CNEntityTypeContacts completionHandler:^(BOOL granted, NSError * _Nullable error) {
         [self checkPermission:callback];
     }];

--- a/ios/RCTContacts/RCTContacts.m
+++ b/ios/RCTContacts/RCTContacts.m
@@ -487,7 +487,7 @@ RCT_EXPORT_METHOD(deleteContact:(NSDictionary *)contactData callback:(RCTRespons
     if(!contactStore) {
         CNContactStore* store = [[CNContactStore alloc] init];
 
-        if(!contactStore.defaultContainerIdentifier) {
+        if(!store.defaultContainerIdentifier) {
             NSLog(@"warn - no contact store container id");
 
             CNAuthorizationStatus authStatus = [CNContactStore authorizationStatusForEntityType:CNEntityTypeContacts];

--- a/ios/RCTContacts/RCTContacts.m
+++ b/ios/RCTContacts/RCTContacts.m
@@ -33,9 +33,7 @@ RCT_EXPORT_METHOD(checkPermission:(RCTResponseSenderBlock) callback)
 
 RCT_EXPORT_METHOD(requestPermission:(RCTResponseSenderBlock) callback)
 {
-    if(!contactStore) {
-        contactStore = [[CNContactStore alloc] init];
-    }
+    CNContactStore* contactStore = [[CNContactStore alloc] init];
 
     [contactStore requestAccessForEntityType:CNEntityTypeContacts completionHandler:^(BOOL granted, NSError * _Nullable error) {
         [self checkPermission:callback];
@@ -45,27 +43,11 @@ RCT_EXPORT_METHOD(requestPermission:(RCTResponseSenderBlock) callback)
 -(void) getAllContacts:(RCTResponseSenderBlock) callback
         withThumbnails:(BOOL) withThumbnails
 {
-    if(!contactStore) {
-        contactStore = [[CNContactStore alloc] init];
-    }
+    CNContactStore* contactStore = [self contactsStore:callback];
+    if(!contactStore)
+        return;
 
-    CNAuthorizationStatus status = [CNContactStore authorizationStatusForEntityType:CNEntityTypeContacts];
-    if(status == CNAuthorizationStatusNotDetermined)
-    {
-        [contactStore requestAccessForEntityType:CNEntityTypeContacts completionHandler:^(BOOL granted, NSError * _Nullable error) {
-            if(granted){
-                [self retrieveContactsFromAddressBook:contactStore withThumbnails:withThumbnails withCallback:callback];
-            } else {
-                callback(@[@{@"type": @"denied"}, [NSNull null]]);
-            }
-        }];
-    }
-    else if(status == CNAuthorizationStatusAuthorized)
-    {
-        [self retrieveContactsFromAddressBook:contactStore withThumbnails:withThumbnails withCallback:callback];
-    } else if (status == CNAuthorizationStatusDenied || status == CNAuthorizationStatusRestricted) {
-        callback(@[@{@"type": @"denied"}, [NSNull null]]);
-    }
+    [self retrieveContactsFromAddressBook:contactStore withThumbnails:withThumbnails withCallback:callback];
 }
 
 RCT_EXPORT_METHOD(getAll:(RCTResponseSenderBlock) callback)
@@ -83,11 +65,11 @@ RCT_EXPORT_METHOD(getAllWithoutPhotos:(RCTResponseSenderBlock) callback)
                            withCallback:(RCTResponseSenderBlock) callback
 {
     NSMutableArray *contacts = [[NSMutableArray alloc] init];
-    
+
     NSError* contactError;
     [contactStore containersMatchingPredicate:[CNContainer predicateForContainersWithIdentifiers: @[contactStore.defaultContainerIdentifier]] error:&contactError];
-    
-    
+
+
     NSMutableArray *keysToFetch = [[NSMutableArray alloc]init];
     [keysToFetch addObjectsFromArray:@[
                                        CNContactEmailAddressesKey,
@@ -100,18 +82,18 @@ RCT_EXPORT_METHOD(getAllWithoutPhotos:(RCTResponseSenderBlock) callback)
                                        CNContactJobTitleKey,
                                        CNContactImageDataAvailableKey
                                        ]];
-    
+
     if(withThumbnails) {
         [keysToFetch addObject:CNContactThumbnailImageDataKey];
     }
-    
+
     CNContactFetchRequest * request = [[CNContactFetchRequest alloc]initWithKeysToFetch:keysToFetch];
     BOOL success = [contactStore enumerateContactsWithFetchRequest:request error:&contactError usingBlock:^(CNContact * __nonnull contact, BOOL * __nonnull stop){
         NSDictionary *contactDict = [self contactToDictionary: contact withThumbnails:withThumbnails];
-        
+
         [contacts addObject:contactDict];
     }];
-    
+
     callback(@[[NSNull null], contacts]);
 }
 
@@ -119,57 +101,57 @@ RCT_EXPORT_METHOD(getAllWithoutPhotos:(RCTResponseSenderBlock) callback)
                       withThumbnails:(BOOL)withThumbnails
 {
     NSMutableDictionary* output = [NSMutableDictionary dictionary];
-    
+
     NSString *recordID = person.identifier;
     NSString *givenName = person.givenName;
     NSString *familyName = person.familyName;
     NSString *middleName = person.middleName;
     NSString *company = person.organizationName;
     NSString *jobTitle = person.jobTitle;
-    
+
     [output setObject:recordID forKey: @"recordID"];
-    
+
     if (givenName) {
         [output setObject: (givenName) ? givenName : @"" forKey:@"givenName"];
     }
-    
+
     if (familyName) {
         [output setObject: (familyName) ? familyName : @"" forKey:@"familyName"];
     }
-    
+
     if(middleName){
         [output setObject: (middleName) ? middleName : @"" forKey:@"middleName"];
     }
-    
+
     if(company){
         [output setObject: (company) ? company : @"" forKey:@"company"];
     }
-    
+
     if(jobTitle){
         [output setObject: (jobTitle) ? jobTitle : @"" forKey:@"jobTitle"];
     }
-    
+
     //handle phone numbers
     NSMutableArray *phoneNumbers = [[NSMutableArray alloc] init];
-    
+
     for (CNLabeledValue<CNPhoneNumber*>* labeledValue in person.phoneNumbers) {
         NSMutableDictionary* phone = [NSMutableDictionary dictionary];
         NSString * label = [CNLabeledValue localizedStringForLabel:[labeledValue label]];
         NSString* value = [[labeledValue value] stringValue];
-        
+
         if(label && value) {
             [phone setObject: value forKey:@"number"];
             [phone setObject: label forKey:@"label"];
             [phoneNumbers addObject:phone];
         }
     }
-    
+
     [output setObject: phoneNumbers forKey:@"phoneNumbers"];
     //end phone numbers
-    
+
     //handle emails
     NSMutableArray *emailAddreses = [[NSMutableArray alloc] init];
-    
+
     for (CNLabeledValue<NSString*>* labeledValue in person.emailAddresses) {
         NSMutableDictionary* email = [NSMutableDictionary dictionary];
         NSString* label = [CNLabeledValue localizedStringForLabel:[labeledValue label]];
@@ -186,17 +168,17 @@ RCT_EXPORT_METHOD(getAllWithoutPhotos:(RCTResponseSenderBlock) callback)
             NSLog(@"ignoring blank email");
         }
     }
-    
+
     [output setObject: emailAddreses forKey:@"emailAddresses"];
     //end emails
-    
+
     //handle postal addresses
     NSMutableArray *postalAddresses = [[NSMutableArray alloc] init];
-    
+
     for (CNLabeledValue<CNPostalAddress*>* labeledValue in person.postalAddresses) {
         CNPostalAddress* postalAddress = labeledValue.value;
         NSMutableDictionary* address = [NSMutableDictionary dictionary];
-        
+
         NSString* street = postalAddress.street;
         if(street){
             [address setObject:street forKey:@"street"];
@@ -217,23 +199,23 @@ RCT_EXPORT_METHOD(getAllWithoutPhotos:(RCTResponseSenderBlock) callback)
         if(country){
             [address setObject:country forKey:@"country"];
         }
-        
+
         NSString* label = [CNLabeledValue localizedStringForLabel:labeledValue.label];
         if(label) {
             [address setObject:label forKey:@"label"];
-            
+
             [postalAddresses addObject:address];
         }
     }
-    
+
     [output setObject:postalAddresses forKey:@"postalAddresses"];
     //end postal addresses
-    
+
     [output setValue:[NSNumber numberWithBool:person.imageDataAvailable] forKey:@"hasThumbnail"];
     if (withThumbnails) {
         [output setObject:[self getFilePathForThumbnailImage:person recordID:recordID] forKey:@"thumbnailPath"];
     }
-    
+
     return output;
 }
 
@@ -247,24 +229,24 @@ RCT_EXPORT_METHOD(getAllWithoutPhotos:(RCTResponseSenderBlock) callback)
 -(NSString *) getFilePathForThumbnailImage:(CNContact*) contact recordID:(NSString*) recordID
 {
     NSString *filepath = [self thumbnailFilePath:recordID];
-    
+
     if([[NSFileManager defaultManager] fileExistsAtPath:filepath]) {
         return filepath;
     }
-    
+
     if (contact.imageDataAvailable){
         NSData *contactImageData = contact.thumbnailImageData;
-        
+
         BOOL success = [[NSFileManager defaultManager] createFileAtPath:filepath contents:contactImageData attributes:nil];
-        
+
         if (!success) {
             NSLog(@"Unable to copy image");
             return @"";
         }
-        
+
         return filepath;
     }
-    
+
     return @"";
 }
 
@@ -276,10 +258,10 @@ RCT_EXPORT_METHOD(getAllWithoutPhotos:(RCTResponseSenderBlock) callback)
 
 RCT_EXPORT_METHOD(getPhotoForId:(nonnull NSString *)recordID callback:(RCTResponseSenderBlock)callback)
 {
-    if(!contactStore) {
-        contactStore = [[CNContactStore alloc] init];
-    }
-    
+    CNContactStore* contactStore = [self contactsStore:callback];
+    if(!contactStore)
+        return;
+
     CNEntityType entityType = CNEntityTypeContacts;
     if([CNContactStore authorizationStatusForEntityType:entityType] == CNAuthorizationStatusNotDetermined)
     {
@@ -299,37 +281,37 @@ RCT_EXPORT_METHOD(getPhotoForId:(nonnull NSString *)recordID callback:(RCTRespon
                                addressBook:(CNContactStore*)addressBook
 {
     NSString *filepath = [self thumbnailFilePath:recordID];
-    
+
     if([[NSFileManager defaultManager] fileExistsAtPath:filepath]) {
         return filepath;
     }
-    
+
     NSError* contactError;
     NSArray * keysToFetch =@[CNContactThumbnailImageDataKey, CNContactImageDataAvailableKey];
     CNContact* contact = [addressBook unifiedContactWithIdentifier:recordID keysToFetch:keysToFetch error:&contactError];
-    
+
     return [self getFilePathForThumbnailImage:contact recordID:recordID];
 }
 
 
 RCT_EXPORT_METHOD(addContact:(NSDictionary *)contactData callback:(RCTResponseSenderBlock)callback)
 {
-    if(!contactStore) {
-        contactStore = [[CNContactStore alloc] init];
-    }
-    
+    CNContactStore* contactStore = [self contactsStore:callback];
+    if(!contactStore)
+        return;
+
     CNMutableContact * contact = [[CNMutableContact alloc] init];
-    
+
     [self updateRecord:contact withData:contactData];
-    
+
     @try {
         CNSaveRequest *request = [[CNSaveRequest alloc] init];
         [request addContact:contact toContainerWithIdentifier:nil];
-        
+
         [contactStore executeSaveRequest:request error:nil];
-        
+
         NSDictionary *contactDict = [self contactToDictionary:contact withThumbnails:false];
-        
+
         callback(@[[NSNull null], contactDict]);
     }
     @catch (NSException *exception) {
@@ -339,10 +321,10 @@ RCT_EXPORT_METHOD(addContact:(NSDictionary *)contactData callback:(RCTResponseSe
 
 RCT_EXPORT_METHOD(updateContact:(NSDictionary *)contactData callback:(RCTResponseSenderBlock)callback)
 {
-    if(!contactStore) {
-        contactStore = [[CNContactStore alloc] init];
-    }
-    
+    CNContactStore* contactStore = [self contactsStore:callback];
+    if(!contactStore)
+        return;
+
     NSError* contactError;
     NSString* recordID = [contactData valueForKey:@"recordID"];
     NSArray * keysToFetch =@[
@@ -358,17 +340,17 @@ RCT_EXPORT_METHOD(updateContact:(NSDictionary *)contactData callback:(RCTRespons
                              CNContactThumbnailImageDataKey,
                              CNContactImageDataKey
                              ];
-    
+
     @try {
         CNMutableContact* record = [[contactStore unifiedContactWithIdentifier:recordID keysToFetch:keysToFetch error:&contactError] mutableCopy];
         [self updateRecord:record withData:contactData];
         CNSaveRequest *request = [[CNSaveRequest alloc] init];
         [request updateContact:record];
-        
+
         [contactStore executeSaveRequest:request error:nil];
-        
+
         NSDictionary *contactDict = [self contactToDictionary:record withThumbnails:false];
-        
+
         callback(@[[NSNull null], contactDict]);
     }
     @catch (NSException *exception) {
@@ -383,19 +365,19 @@ RCT_EXPORT_METHOD(updateContact:(NSDictionary *)contactData callback:(RCTRespons
     NSString *middleName = [contactData valueForKey:@"middleName"];
     NSString *company = [contactData valueForKey:@"company"];
     NSString *jobTitle = [contactData valueForKey:@"jobTitle"];
-    
+
     contact.givenName = givenName;
     contact.familyName = familyName;
     contact.middleName = middleName;
     contact.organizationName = company;
     contact.jobTitle = jobTitle;
-    
+
     NSMutableArray *phoneNumbers = [[NSMutableArray alloc]init];
-    
+
     for (id phoneData in [contactData valueForKey:@"phoneNumbers"]) {
         NSString *label = [phoneData valueForKey:@"label"];
         NSString *number = [phoneData valueForKey:@"number"];
-        
+
         CNLabeledValue *phone;
         if ([label isEqual: @"main"]){
             phone = [[CNLabeledValue alloc] initWithLabel:CNLabelPhoneNumberMain value:[[CNPhoneNumber alloc] initWithStringValue:number]];
@@ -409,28 +391,28 @@ RCT_EXPORT_METHOD(updateContact:(NSDictionary *)contactData callback:(RCTRespons
         else{
             phone = [[CNLabeledValue alloc] initWithLabel:label value:[[CNPhoneNumber alloc] initWithStringValue:number]];
         }
-        
+
         [phoneNumbers addObject:phone];
     }
     contact.phoneNumbers = phoneNumbers;
-    
+
     NSMutableArray *emails = [[NSMutableArray alloc]init];
-    
+
     for (id emailData in [contactData valueForKey:@"emailAddresses"]) {
         NSString *label = [emailData valueForKey:@"label"];
         NSString *email = [emailData valueForKey:@"email"];
-        
+
         if(label && email) {
             [emails addObject:[[CNLabeledValue alloc] initWithLabel:label value:email]];
         }
     }
-    
+
     contact.emailAddresses = emails;
-    
+
     //todo - update postal addresses
-    
+
     NSString *thumbnailPath = [contactData valueForKey:@"thumbnailPath"];
-    
+
     if(thumbnailPath && [thumbnailPath rangeOfString:@"rncontacts_"].location == NSNotFound) {
         contact.imageData = [RCTContacts imageData:thumbnailPath];
     }
@@ -451,7 +433,7 @@ enum { WDASSETURL_PENDINGREADS = 1, WDASSETURL_ALLFINISHED = 0};
 
 + (NSData*) loadImageAsset:(NSURL*)assetURL {
     //thanks to http://www.codercowboy.com/code-synchronous-alassetlibrary-asset-existence-check/
-    
+
     __block NSData *data = nil;
     __block NSConditionLock * albumReadLock = [[NSConditionLock alloc] initWithCondition:WDASSETURL_PENDINGREADS];
     //this *MUST* execute on a background thread, ALAssetLibrary tries to use the main thread and will hang if you're on the main thread.
@@ -460,26 +442,26 @@ enum { WDASSETURL_PENDINGREADS = 1, WDASSETURL_ALLFINISHED = 0};
         [assetLibrary assetForURL:assetURL
                       resultBlock:^(ALAsset *asset) {
                           ALAssetRepresentation *rep = [asset defaultRepresentation];
-                          
+
                           Byte *buffer = (Byte*)malloc(rep.size);
                           NSUInteger buffered = [rep getBytes:buffer fromOffset:0.0 length:rep.size error:nil];
                           data = [NSData dataWithBytesNoCopy:buffer length:buffered freeWhenDone:YES];
-                          
+
                           [albumReadLock lock];
                           [albumReadLock unlockWithCondition:WDASSETURL_ALLFINISHED];
                       } failureBlock:^(NSError *error) {
                           NSLog(@"asset error: %@", [error localizedDescription]);
-                          
+
                           [albumReadLock lock];
                           [albumReadLock unlockWithCondition:WDASSETURL_ALLFINISHED];
                       }];
     });
-    
+
     [albumReadLock lockWhenCondition:WDASSETURL_ALLFINISHED];
     [albumReadLock unlock];
-    
+
     NSLog(@"asset lookup finished: %@ %@", [assetURL absoluteString], (data ? @"exists" : @"does not exist"));
-    
+
     return data;
 }
 
@@ -488,17 +470,40 @@ RCT_EXPORT_METHOD(deleteContact:(NSDictionary *)contactData callback:(RCTRespons
     if(!contactStore) {
         contactStore = [[CNContactStore alloc] init];
     }
-    
+
     NSString* recordID = [contactData valueForKey:@"recordID"];
-    
+
     NSArray *keys = @[CNContactIdentifierKey];
     CNMutableContact *contact = [[contactStore unifiedContactWithIdentifier:recordID keysToFetch:keys error:nil] mutableCopy];
     NSError *error;
     CNSaveRequest *saveRequest = [[CNSaveRequest alloc] init];
     [saveRequest deleteContact:contact];
     [contactStore executeSaveRequest:saveRequest error:&error];
-    
+
     callback(@[[NSNull null], [NSNull null]]);
+}
+
+-(CNContactStore*) contactsStore: (RCTResponseSenderBlock)callback {
+    if(!contactStore) {
+        CNContactStore* store = [[CNContactStore alloc] init];
+
+        if(!contactStore.defaultContainerIdentifier) {
+            NSLog(@"warn - no contact store container id");
+
+            CNAuthorizationStatus authStatus = [CNContactStore authorizationStatusForEntityType:CNEntityTypeContacts];
+            if (authStatus == CNAuthorizationStatusDenied || authStatus == CNAuthorizationStatusRestricted){
+                callback(@[@"denied", [NSNull null]]);
+            } else {
+                callback(@[@"undefined", [NSNull null]]);
+            }
+
+            return nil;
+        }
+
+        contactStore = store;
+    }
+
+    return contactStore;
 }
 
 @end


### PR DESCRIPTION
Made all methods return a 'denied' error if permissions are not set up
GetAll no longer lazily requests permissions so its behaviour is more consistent with the other methods
Upgraded remaining methods using the old 'AB' api to use the new CNContactsStore api