### PR TITLE
Issue #167 : Implement native filtering by string

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,27 @@ var Contacts = require('react-native-contacts')
 
 Contacts.getAll((err, contacts) => {
   if(err === 'denied'){
-    // x.x
+    // error
   } else {
-    console.log(contacts)
+    // contacts returned in []
   }
 })
 ```
 
+`getContactMatchingString` is meant to alleviate the amount of time it takes to get all contacts, by filtering on the native side based on a string.
+
+```js
+var Contacts = require('react-native-contacts')
+
+Contacts.getContactsMatchingString("filter", (err, contacts) => {
+  if(err === 'denied'){
+    // x.x
+  } else {
+    // Contains only contacts matching "filter"
+    console.log(contacts)
+  }
+})
+```
 ## Installation
 run `npm install react-native-contacts`
 
@@ -99,6 +113,7 @@ dependencies {
 | `addContact` | ✔ | ✔ |
 | `updateContact` | ✔ | ✔ |
 | `deleteContact` | ✔ | 😞 |
+| `getContactsMatchingString` | ✔ | ✔ |
 | get with options | 😞 | 😞 |
 | groups  | 😞 | 😞 |
 
@@ -111,6 +126,7 @@ dependencies {
  * `addContact` (contact, callback) - adds a contact to the AddressBook.  
  * `updateContact` (contact, callback) - where contact is an object with a valid recordID  
  * `deleteContact` (contact, callback) - where contact is an object with a valid recordID  
+ * `getContactsMatchingString` (string, callback) - where string is any string to match a name (first, middle, family) to
  * `checkPermission` (callback) - checks permission to access Contacts  
  * `requestPermission` (callback) - request permission to access Contacts
 

--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
@@ -49,7 +49,7 @@ public class ContactsManager extends ReactContextBaseJavaModule {
     /**
      * Retrieves contacts.
      * Uses raw URI when <code>rawUri</code> is <code>true</code>, makes assets copy otherwise.
-     * @param callback callback
+     * @param callback user provided callback to run at completion
      */
     private void getAllContacts(final Callback callback) {
         AsyncTask.execute(new Runnable() {
@@ -60,6 +60,33 @@ public class ContactsManager extends ReactContextBaseJavaModule {
 
                 ContactsProvider contactsProvider = new ContactsProvider(cr);
                 WritableArray contacts = contactsProvider.getContacts();
+
+                callback.invoke(null, contacts);
+            }
+        });
+    }
+
+    /*
+     * Returns all contacts matching string
+     */
+    @ReactMethod
+    public void getContactsMatchingString(final String searchString, final Callback callback) {
+        getAllContactsMatchingString(searchString, callback);
+    }
+    /**
+     * Retrieves contacts matching String.
+     * Uses raw URI when <code>rawUri</code> is <code>true</code>, makes assets copy otherwise.
+     * @param searchString String to match
+     * @param callback user provided callback to run at completion
+     */
+    private void getAllContactsMatchingString(final String searchString, final Callback callback) {
+        AsyncTask.execute(new Runnable() {
+            @Override
+            public void run() {
+                Context context = getReactApplicationContext();
+                ContentResolver cr = context.getContentResolver();
+                ContactsProvider contactsProvider = new ContactsProvider(cr);
+                WritableArray contacts = contactsProvider.getContactsMatchingString(searchString);
 
                 callback.invoke(null, contacts);
             }

--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsProvider.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsProvider.java
@@ -15,7 +15,6 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-
 import static android.provider.ContactsContract.CommonDataKinds.Contactables;
 import static android.provider.ContactsContract.CommonDataKinds.Email;
 import static android.provider.ContactsContract.CommonDataKinds.Organization;
@@ -72,6 +71,33 @@ public class ContactsProvider {
 
     public ContactsProvider(ContentResolver contentResolver) {
         this.contentResolver = contentResolver;
+    }
+
+    public WritableArray getContactsMatchingString(String searchString) {
+        Map<String, Contact> matchingContacts;
+        {
+            Cursor cursor = contentResolver.query(
+                    ContactsContract.Data.CONTENT_URI,
+                    FULL_PROJECTION.toArray(new String[FULL_PROJECTION.size()]),
+                    ContactsContract.Contacts.DISPLAY_NAME_PRIMARY + " LIKE ?",
+                    new String[]{"%" + searchString + "%"},
+                    null
+            );
+
+            try {
+                matchingContacts = loadContactsFrom(cursor);
+            } finally {
+                if (cursor != null) {
+                    cursor.close();
+                }
+            }
+        }
+
+        WritableArray contacts = Arguments.createArray();
+        for (Contact contact : matchingContacts.values()) {
+            contacts.pushMap(contact.toMap());
+        }
+        return contacts;
     }
 
     public WritableArray getContacts() {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/rt2zz/react-native-contacts.git"
   },
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "React Native Contacts (android & ios)",
   "nativePackage": true,
   "keywords": [


### PR DESCRIPTION
This allows one to match a string to a contact's first, middle or last name on the native side. It allows one to not have to pass the entire list of contacts to ReactNative, thus speeding up situations in which a user may have hundreds or thousands of contacts.

Closes #167 