### PR TITLE
fixed typo "city" -> "state"

### DIFF
--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsProvider.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsProvider.java
@@ -336,6 +336,7 @@ public class ContactsProvider {
                 putString(cursor, "neighborhood", StructuredPostal.NEIGHBORHOOD);
                 putString(cursor, "city", StructuredPostal.CITY);
                 putString(cursor, "region", StructuredPostal.REGION);
+                putString(cursor, "state", StructuredPostal.REGION);
                 putString(cursor, "postCode", StructuredPostal.POSTCODE);
                 putString(cursor, "country", StructuredPostal.COUNTRY);
             }

--- a/ios/RCTContacts/RCTContacts.m
+++ b/ios/RCTContacts/RCTContacts.m
@@ -190,6 +190,10 @@ RCT_EXPORT_METHOD(getAllWithoutPhotos:(RCTResponseSenderBlock) callback)
         if(city){
             [address setObject:city forKey:@"city"];
         }
+        NSString* state = postalAddress.state;
+        if(state){
+            [address setObject:state forKey:@"state"];
+        }
         NSString* region = postalAddress.state;
         if(region){
             [address setObject:region forKey:@"region"];

--- a/ios/RCTContacts/RCTContacts.m
+++ b/ios/RCTContacts/RCTContacts.m
@@ -190,7 +190,7 @@ RCT_EXPORT_METHOD(getAllWithoutPhotos:(RCTResponseSenderBlock) callback)
         if(city){
             [address setObject:city forKey:@"city"];
         }
-        NSString* region = postalAddress.city;
+        NSString* region = postalAddress.state;
         if(region){
             [address setObject:region forKey:@"region"];
         }


### PR DESCRIPTION
1) Noticed "region" line was set to "city", maybe copy-paste error from line 189?
2) According to Apple docs for [CNPostalAddress](https://developer.apple.com/reference/contacts/cnpostaladdress) it seems this field is called "state"?  I left the resulting property name as "region" so as to not make a breaking change for anyone currently using it.

Let me know if I am wrong in either of those assumptions.