### PR TITLE
addContact, updateContact, deleteContact improved/implemented with feature parity in both Android and IOS.

### DIFF
--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
@@ -61,7 +61,7 @@ public class ContactsManager extends ReactContextBaseJavaModule {
     /**
      * Retrieves contacts.
      * Uses raw URI when <code>rawUri</code> is <code>true</code>, makes assets copy otherwise.
-     * @param callback callback
+     * @param callback user provided callback to run at completion
      */
     private void getAllContacts(final Callback callback) {
         AsyncTask.execute(new Runnable() {
@@ -72,6 +72,33 @@ public class ContactsManager extends ReactContextBaseJavaModule {
 
                 ContactsProvider contactsProvider = new ContactsProvider(cr);
                 WritableArray contacts = contactsProvider.getContacts();
+
+                callback.invoke(null, contacts);
+            }
+        });
+    }
+
+    /*
+     * Returns all contacts matching string
+     */
+    @ReactMethod
+    public void getContactsMatchingString(final String searchString, final Callback callback) {
+        getAllContactsMatchingString(searchString, callback);
+    }
+    /**
+     * Retrieves contacts matching String.
+     * Uses raw URI when <code>rawUri</code> is <code>true</code>, makes assets copy otherwise.
+     * @param searchString String to match
+     * @param callback user provided callback to run at completion
+     */
+    private void getAllContactsMatchingString(final String searchString, final Callback callback) {
+        AsyncTask.execute(new Runnable() {
+            @Override
+            public void run() {
+                Context context = getReactApplicationContext();
+                ContentResolver cr = context.getContentResolver();
+                ContactsProvider contactsProvider = new ContactsProvider(cr);
+                WritableArray contacts = contactsProvider.getContactsMatchingString(searchString);
 
                 callback.invoke(null, contacts);
             }

--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsProvider.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsProvider.java
@@ -100,6 +100,62 @@ public class ContactsProvider {
         return contacts;
     }
 
+     public WritableMap getContactByRawId(String contactRawId) {
+
+        // Get Contact Id from Raw Contact Id
+        String[] projections = new String[]{ContactsContract.RawContacts.CONTACT_ID};
+        String select = ContactsContract.RawContacts._ID + "= ?";
+        String[] selectionArgs = new String[]{contactRawId};
+        Cursor rawCursor = contentResolver.query(ContactsContract.RawContacts.CONTENT_URI, projections, select, selectionArgs, null);
+        String contactId = null;
+        if (rawCursor.getCount() == 0) {
+            /*contact id not found */
+        }
+
+        if (rawCursor.moveToNext()) {
+            int columnIndex;
+            columnIndex = rawCursor.getColumnIndex(ContactsContract.RawContacts.CONTACT_ID);
+            if (columnIndex == -1) {
+                /* trouble getting contact id */
+            } else {
+                contactId = rawCursor.getString(columnIndex);
+            }
+        }
+
+        rawCursor.close();
+
+        //Now that we have the real contact id, fetch information
+        return getContactById(contactId);
+    }
+
+    public WritableMap getContactById(String contactId) {
+
+        Map<String, Contact> matchingContacts;
+        {
+            Cursor cursor = contentResolver.query(
+                ContactsContract.Data.CONTENT_URI,
+                FULL_PROJECTION.toArray(new String[FULL_PROJECTION.size()]),
+                ContactsContract.RawContacts.CONTACT_ID + " = ?",
+                new String[]{contactId},
+                null
+            );
+
+            try {
+                matchingContacts = loadContactsFrom(cursor);
+            } finally {
+                if (cursor != null) {
+                    cursor.close();
+                }
+            }
+        }
+        
+        if(matchingContacts.values().size() > 0) {
+            return matchingContacts.values().iterator().next().toMap();
+        }
+        
+       return null;
+    }
+
     public WritableArray getContacts() {
         Map<String, Contact> justMe;
         {

--- a/ios/RCTContacts/RCTContacts.m
+++ b/ios/RCTContacts/RCTContacts.m
@@ -511,13 +511,21 @@ RCT_EXPORT_METHOD(deleteContact:(NSDictionary *)contactData callback:(RCTRespons
     NSString* recordID = [contactData valueForKey:@"recordID"];
 
     NSArray *keys = @[CNContactIdentifierKey];
-    CNMutableContact *contact = [[contactStore unifiedContactWithIdentifier:recordID keysToFetch:keys error:nil] mutableCopy];
-    NSError *error;
-    CNSaveRequest *saveRequest = [[CNSaveRequest alloc] init];
-    [saveRequest deleteContact:contact];
-    [contactStore executeSaveRequest:saveRequest error:&error];
+    
+    
+    @try {
+        
+        CNMutableContact *contact = [[contactStore unifiedContactWithIdentifier:recordID keysToFetch:keys error:nil] mutableCopy];
+        NSError *error;
+        CNSaveRequest *saveRequest = [[CNSaveRequest alloc] init];
+        [saveRequest deleteContact:contact];
+        [contactStore executeSaveRequest:saveRequest error:&error];
 
-    callback(@[[NSNull null], [NSNull null]]);
+        callback(@[[NSNull null], recordID]);
+    }
+    @catch (NSException *exception) {
+        callback(@[[exception description], [NSNull null]]);
+    }
 }
 
 -(CNContactStore*) contactsStore: (RCTResponseSenderBlock)callback {


### PR DESCRIPTION
Android: 
 1. **addContact** : now uses thumbnailPath to get the file it points to so it can decode a Bitmap and associate to the respective Contact. From my tests, if the photo is obtained from an Image Picker and has a path that starts something like "file:///path/to/file", the prefix "file:///" should be removed before saving to thumbnailPath property - in the above example, should be: "/path/to/file". **IOS** version already implemented this by default.

2. **deleteContact**: implemented. Returns (error, recordID), where recordID is the ID of the deleted record in case of successful deletion.

closes #161 