### PR TITLE
As of RN 0.47 modules no longer need to override createJsModules.

### DIFF
--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ReactNativeContacts.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ReactNativeContacts.java
@@ -1,14 +1,12 @@
 package com.rt2zz.reactnativecontacts;
 
 import com.facebook.react.ReactPackage;
-import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 public class ReactNativeContacts implements ReactPackage {
@@ -20,11 +18,6 @@ public class ReactNativeContacts implements ReactPackage {
 
         modules.add(new ContactsManager(reactContext));
         return modules;
-    }
-
-    @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
     }
 
     @Override


### PR DESCRIPTION
React-Native 0.47 change log: https://github.com/facebook/react-native/releases/tag/v0.47.0

I will leave updating the Readme to you since you will have to specify the different versions.

