### PR TITLE
Add PostalAddresses for ios and android

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,17 +111,17 @@ Add permissions to your `android/app/src/main/AndroidManifest.xml` file.  Add on
   }],
   hasThumbnail: true,
   thumbnailPath: 'content://com.android.contacts/display_photo/3',
-  postalAddresses:
-    [
-      {
-        postCode: 'Postcooode',
-        city: 'City',
-        neighborhood: 'neighborhood',
-        street: 'Home Street',
-        formattedAddress: 'Home Street\nneighborhood\nCity Postcooode',
-        label: 'work'
-      }
-    ]
+  postalAddresses: [
+    {
+      street: '123 Fake Street',
+      city: 'Sample City',
+      state: 'CA',
+      region: 'CA',
+      postCode: '90210',
+      country: 'USA',
+      label: 'home'
+    }
+  ]
 }
 ```
 **NOTE**

--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
@@ -209,6 +209,25 @@ public class ContactsManager extends ReactContextBaseJavaModule {
             ops.add(op.build());
         }
 
+        ReadableArray postalAddresses = contact.hasKey("postalAddresses") ? contact.getArray("postalAddresses") : null;
+        if (postalAddresses != null) {
+            for (int i = 0; i <  postalAddresses.size() ; i++) {
+                ReadableMap address = postalAddresses.getMap(i);
+
+                op = ContentProviderOperation.newInsert(ContactsContract.Data.CONTENT_URI)
+                        .withValueBackReference(ContactsContract.Data.RAW_CONTACT_ID, 0)
+                        .withValue(ContactsContract.Data.MIMETYPE, CommonDataKinds.StructuredPostal.CONTENT_ITEM_TYPE)
+                        .withValue(CommonDataKinds.StructuredPostal.TYPE, mapStringToPostalAddressType(address.getString("label")))
+                        .withValue(CommonDataKinds.StructuredPostal.STREET, address.getString("street"))
+                        .withValue(CommonDataKinds.StructuredPostal.CITY, address.getString("city"))
+                        .withValue(CommonDataKinds.StructuredPostal.REGION, address.getString("state"))
+                        .withValue(CommonDataKinds.StructuredPostal.POSTCODE, address.getString("postCode"))
+                        .withValue(CommonDataKinds.StructuredPostal.COUNTRY, address.getString("country"));
+
+                ops.add(op.build());
+            }
+        }
+
         Context ctx = getReactApplicationContext();
         try {
             ContentResolver cr = ctx.getContentResolver();

--- a/ios/RCTContacts/RCTContacts.m
+++ b/ios/RCTContacts/RCTContacts.m
@@ -450,7 +450,29 @@ RCT_EXPORT_METHOD(updateContact:(NSDictionary *)contactData callback:(RCTRespons
 
     contact.emailAddresses = emails;
 
-    //todo - update postal addresses
+    NSMutableArray *postalAddresses = [[NSMutableArray alloc]init];
+    
+    for (id addressData in [contactData valueForKey:@"postalAddresses"]) {
+        NSString *label = [addressData valueForKey:@"label"];
+        NSString *street = [addressData valueForKey:@"street"];
+        NSString *region = [addressData valueForKey:@"region"];
+        NSString *postalCode = [addressData valueForKey:@"postalCode"];
+        NSString *city = [addressData valueForKey:@"city"];
+        NSString *country = [addressData valueForKey:@"country"];
+        NSString *state = [addressData valueForKey:@"state"];
+        
+        if(label && street) {
+            CNMutablePostalAddress *postalAddr = [[CNMutablePostalAddress alloc] init];
+            postalAddr.street = street;
+            postalAddr.postalCode = postalCode;
+            postalAddr.city = city;
+            postalAddr.country = country;
+            postalAddr.state = state;
+            [postalAddresses addObject:[[CNLabeledValue alloc] initWithLabel:label value: postalAddr]];
+        }
+    }
+    
+    contact.postalAddresses = postalAddresses;
 
     NSString *thumbnailPath = [contactData valueForKey:@"thumbnailPath"];
 

--- a/ios/RCTContacts/RCTContacts.m
+++ b/ios/RCTContacts/RCTContacts.m
@@ -455,7 +455,6 @@ RCT_EXPORT_METHOD(updateContact:(NSDictionary *)contactData callback:(RCTRespons
     for (id addressData in [contactData valueForKey:@"postalAddresses"]) {
         NSString *label = [addressData valueForKey:@"label"];
         NSString *street = [addressData valueForKey:@"street"];
-        NSString *region = [addressData valueForKey:@"region"];
         NSString *postalCode = [addressData valueForKey:@"postalCode"];
         NSString *city = [addressData valueForKey:@"city"];
         NSString *country = [addressData valueForKey:@"country"];

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/rt2zz/react-native-contacts.git"
   },
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "React Native Contacts (android & ios)",
   "nativePackage": true,
   "keywords": [


### PR DESCRIPTION
PostalAddresses will now be added with AddContact
Fixed for both iOS and Android
Follow updated README for the correct formatting in AddContact 

Solving issue [#210](https://github.com/rt2zz/react-native-contacts/issues/210)

Looks like someone already created a [test for this](https://github.com/morenoh149/react-native-contacts-test/pull/3)