### PR TITLE
Bug fix for Android PostalAddress

### DIFF
--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
@@ -415,6 +415,22 @@ public class ContactsManager extends ReactContextBaseJavaModule {
         return emailType;
     }
 
+    private int mapStringToPostalAddressType(String label) {
+        int postalAddressType;
+        switch (label) {
+            case "home":
+                postalAddressType = CommonDataKinds.StructuredPostal.TYPE_HOME;
+                break;
+            case "work":
+                postalAddressType = CommonDataKinds.StructuredPostal.TYPE_WORK;
+                break;
+            default:
+                postalAddressType = CommonDataKinds.StructuredPostal.TYPE_OTHER;
+                break;
+        }
+        return postalAddressType;
+    }
+
     @Override
     public String getName() {
         return "Contacts";


### PR DESCRIPTION
Forgot this little function! It's called on line 220 but I forgot to include it. This is in reference to my last [PR](https://github.com/rt2zz/react-native-contacts/pull/212) that added PostalAddresses for both iOS and android. iOS is working fine, Android is broken until this gets merged in. 