### PR TITLE
Replacing NSLog with RCTLog

### DIFF
--- a/ios/RCTContacts/RCTContacts.m
+++ b/ios/RCTContacts/RCTContacts.m
@@ -3,6 +3,7 @@
 #import "RCTContacts.h"
 #import <Contacts/Contacts.h>
 #import <AssetsLibrary/AssetsLibrary.h>
+#import <React/RCTLog.h>
 
 @implementation RCTContacts {
     CNContactStore * contactStore;
@@ -202,7 +203,7 @@ RCT_EXPORT_METHOD(getAllWithoutPhotos:(RCTResponseSenderBlock) callback)
             [email setObject: label forKey:@"label"];
             [emailAddreses addObject:email];
         } else {
-            NSLog(@"ignoring blank email");
+            RCTLog(@"ignoring blank email");
         }
     }
 
@@ -281,7 +282,7 @@ RCT_EXPORT_METHOD(getAllWithoutPhotos:(RCTResponseSenderBlock) callback)
         BOOL success = [[NSFileManager defaultManager] createFileAtPath:filepath contents:contactImageData attributes:nil];
 
         if (!success) {
-            NSLog(@"Unable to copy image");
+            RCTLog(@"Unable to copy image");
             return @"";
         }
 
@@ -512,7 +513,7 @@ enum { WDASSETURL_PENDINGREADS = 1, WDASSETURL_ALLFINISHED = 0};
                           [albumReadLock lock];
                           [albumReadLock unlockWithCondition:WDASSETURL_ALLFINISHED];
                       } failureBlock:^(NSError *error) {
-                          NSLog(@"asset error: %@", [error localizedDescription]);
+                          RCTLog(@"asset error: %@", [error localizedDescription]);
 
                           [albumReadLock lock];
                           [albumReadLock unlockWithCondition:WDASSETURL_ALLFINISHED];
@@ -522,7 +523,7 @@ enum { WDASSETURL_PENDINGREADS = 1, WDASSETURL_ALLFINISHED = 0};
     [albumReadLock lockWhenCondition:WDASSETURL_ALLFINISHED];
     [albumReadLock unlock];
 
-    NSLog(@"asset lookup finished: %@ %@", [assetURL absoluteString], (data ? @"exists" : @"does not exist"));
+    RCTLog(@"asset lookup finished: %@ %@", [assetURL absoluteString], (data ? @"exists" : @"does not exist"));
 
     return data;
 }
@@ -550,7 +551,7 @@ RCT_EXPORT_METHOD(deleteContact:(NSDictionary *)contactData callback:(RCTRespons
         CNContactStore* store = [[CNContactStore alloc] init];
 
         if(!store.defaultContainerIdentifier) {
-            NSLog(@"warn - no contact store container id");
+            RCTLog(@"warn - no contact store container id");
 
             CNAuthorizationStatus authStatus = [CNContactStore authorizationStatusForEntityType:CNEntityTypeContacts];
             if (authStatus == CNAuthorizationStatusDenied || authStatus == CNAuthorizationStatusRestricted){


### PR DESCRIPTION
NSLog print the logs in release mode as well. Its better to use RCTLog as that will be printed only in debug builds and governed by RCTLOG_ENABLED