### PR TITLE
Modify 'Header Search Path' for native iOS app to integrate react-nat…

### DIFF
--- a/ios/RCTContacts.xcodeproj/project.pbxproj
+++ b/ios/RCTContacts.xcodeproj/project.pbxproj
@@ -138,6 +138,7 @@
 					"$(inherited)",
 					"$(SRCROOT)/../../../React/**",
 					"$(SRCROOT)/../../react-native/React/**",
+					"$(BUILT_PRODUCTS_DIR)",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -152,6 +153,7 @@
 					"$(inherited)",
 					"$(SRCROOT)/../../../React/**",
 					"$(SRCROOT)/../../react-native/React/**",
+					"$(BUILT_PRODUCTS_DIR)",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/react-native-contacts.podspec
+++ b/react-native-contacts.podspec
@@ -13,4 +13,6 @@ Pod::Spec.new do |s|
   s.source         = { :git => package_json["repository"]["url"] }
   s.source_files   = 'ios/RCTContacts/*.{h,m}'
 
+  s.dependency 'React'
+
 end


### PR DESCRIPTION
Modify 'Header Search Path' for native iOS app to integrate react-native-contacts from react-native package.json.
```
In file included from /Users/OceanHorn/SourceTree/mmms/node_modules/react-native-contacts/ios/RCTContacts/RCTContacts.m:3:
/Users/OceanHorn/SourceTree/mmms/node_modules/react-native-contacts/ios/RCTContacts/RCTContacts.h:1:9: fatal error: 'React/RCTBridgeModule.h' file not found
#import <React/RCTBridgeModule.h>
        ^~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```
fixes #305 