### PR TITLE
Add requiresMainQueueSetup on iOS

### DIFF
--- a/ios/RCTContacts/RCTContacts.m
+++ b/ios/RCTContacts/RCTContacts.m
@@ -9,6 +9,11 @@
 
 RCT_EXPORT_MODULE();
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 - (NSDictionary *)constantsToExport
 {
     return @{


### PR DESCRIPTION
* introduced in RN 51, apps must specify if they should use the main
application thread.
* fixes #246