### PR TITLE
Fix for saving postal codes

### DIFF
--- a/ios/RCTContacts/RCTContacts.m
+++ b/ios/RCTContacts/RCTContacts.m
@@ -521,7 +521,7 @@ RCT_EXPORT_METHOD(updateContact:(NSDictionary *)contactData callback:(RCTRespons
     for (id addressData in [contactData valueForKey:@"postalAddresses"]) {
         NSString *label = [addressData valueForKey:@"label"];
         NSString *street = [addressData valueForKey:@"street"];
-        NSString *postalCode = [addressData valueForKey:@"postalCode"];
+        NSString *postalCode = [addressData valueForKey:@"postCode"];
         NSString *city = [addressData valueForKey:@"city"];
         NSString *country = [addressData valueForKey:@"country"];
         NSString *state = [addressData valueForKey:@"state"];


### PR DESCRIPTION
Fixes a bug where updating a contact’s postal address on iOS did not
properly save the postal code / zip code field