### PR TITLE
Cleanup Gradle config

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,13 +10,17 @@ buildscript {
 
 apply plugin: 'com.android.library'
 
+def DEFAULT_COMPILE_SDK_VERSION             = 25
+def DEFAULT_TARGET_SDK_VERSION              = 22
+def DEFAULT_BUILD_TOOLS_VERSION             = '25.0.0'
+
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.0"
+    compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
+    buildToolsVersion rootProject.hasProperty('buildToolsVersion') ? rootProject.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion rootProject.hasProperty('targetSdkVersion') ? rootProject.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
         versionCode 1
         versionName "1.0"
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,9 +10,9 @@ buildscript {
 
 apply plugin: 'com.android.library'
 
-def DEFAULT_COMPILE_SDK_VERSION             = 25
-def DEFAULT_TARGET_SDK_VERSION              = 22
-def DEFAULT_BUILD_TOOLS_VERSION             = '25.0.0'
+def DEFAULT_COMPILE_SDK_VERSION             = 27
+def DEFAULT_TARGET_SDK_VERSION              = 27
+def DEFAULT_BUILD_TOOLS_VERSION             = '27.0.3'
 
 android {
     compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION


### PR DESCRIPTION
Fixes https://github.com/rt2zz/react-native-contacts/issues/303

## The Problem

Enforcing a compile SDK version breaks compilation for people that don't have it installed. The app itself could be using another SDK version and this package does not respect that.

RN App compilation fails with errors like

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':react-native-contacts:platformAttrExtractor'.
> A failure occurred while executing com.android.build.gradle.internal.actions.AttrExtractor
   > ~/Library/Android/sdk/platforms/android-25/android.jar (No such file or directory)
```

## The solution

I've changed the gradle config to respect root project's config in terms of compile, sdk and build tools version. It still falls back to the current defaults if the variables aren't defined. This is a non-breaking change.

It seems to be a standard practice for RN android packages like [react-native-push-notification](https://github.com/zo0r/react-native-push-notification/blob/6b732623c62f3b4fdbcc47aa786556ae23da17a7/android/build.gradle#L18-L20), [react-native-google-places](https://github.com/tolu360/react-native-google-places/blob/8ead774b6a6785580b1a7214f1a9b98b1ef635ef/android/build.gradle#L3-L5) and [tipsi-stripe](https://github.com/tipsi/tipsi-stripe/blob/d9c8be08b7ce3757f6bc5ee5198f46c63a38e2c1/android/build.gradle#L3-L5)