### PR TITLE
Add url and note support for react-native-contacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,10 @@ callback <Function>
   givenName: "Carl",
   jobTitle: "",
   note: 'some text',
-  url: 'www.jung.com',
+  urlAddresses: [{
+    label: "home",
+    url: "www.jung.com",
+  }],
   middleName: "",
   phoneNumbers: [{
     label: "mobile",

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ callback <Function>
   familyName: "Jung",
   givenName: "Carl",
   jobTitle: "",
+  note: 'some text',
+  url: 'www.jung.com',
   middleName: "",
   phoneNumbers: [{
     label: "mobile",

--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
@@ -18,6 +18,8 @@ import android.provider.ContactsContract;
 import android.provider.ContactsContract.CommonDataKinds;
 import android.provider.ContactsContract.CommonDataKinds.Organization;
 import android.provider.ContactsContract.CommonDataKinds.StructuredName;
+import android.provider.ContactsContract.CommonDataKinds.Note;
+import android.provider.ContactsContract.CommonDataKinds.Website;
 import android.provider.ContactsContract.RawContacts;
 import android.support.annotation.NonNull;
 import android.support.v4.app.ActivityCompat;
@@ -288,6 +290,8 @@ public class ContactsManager extends ReactContextBaseJavaModule {
         String company = contact.hasKey("company") ? contact.getString("company") : null;
         String jobTitle = contact.hasKey("jobTitle") ? contact.getString("jobTitle") : null;
         String department = contact.hasKey("department") ? contact.getString("department") : null;
+        String note = contact.hasKey("note") ? contact.getString("note") : null;
+        String url = contact.hasKey("url") ? contact.getString("url") : null;
         String thumbnailPath = contact.hasKey("thumbnailPath") ? contact.getString("thumbnailPath") : null;
 
         ReadableArray phoneNumbers = contact.hasKey("phoneNumbers") ? contact.getArray("phoneNumbers") : null;
@@ -336,6 +340,18 @@ public class ContactsManager extends ReactContextBaseJavaModule {
                 .withValue(StructuredName.FAMILY_NAME, familyName)
                 .withValue(StructuredName.PREFIX, prefix)
                 .withValue(StructuredName.SUFFIX, suffix);
+        ops.add(op.build());
+ 
+        op = ContentProviderOperation.newInsert(ContactsContract.Data.CONTENT_URI)
+                .withValueBackReference(ContactsContract.Data.RAW_CONTACT_ID, 0)
+                .withValue(ContactsContract.Data.MIMETYPE, Note.CONTENT_ITEM_TYPE)
+                .withValue(ContactsContract.CommonDataKinds.Note.NOTE, note);
+        ops.add(op.build());
+
+        op = ContentProviderOperation.newInsert(ContactsContract.Data.CONTENT_URI)
+                .withValueBackReference(ContactsContract.Data.RAW_CONTACT_ID, 0)
+                .withValue(ContactsContract.Data.MIMETYPE, Website.CONTENT_ITEM_TYPE)
+                .withValue(ContactsContract.CommonDataKinds.Website.URL, url);
         ops.add(op.build());
 
         op = ContentProviderOperation.newInsert(ContactsContract.Data.CONTENT_URI)
@@ -440,6 +456,8 @@ public class ContactsManager extends ReactContextBaseJavaModule {
         String company = contact.hasKey("company") ? contact.getString("company") : null;
         String jobTitle = contact.hasKey("jobTitle") ? contact.getString("jobTitle") : null;
         String department = contact.hasKey("department") ? contact.getString("department") : null;
+        String note = contact.hasKey("note") ? contact.getString("note") : null;
+        String url = contact.hasKey("url") ? contact.getString("url") : null;
         String thumbnailPath = contact.hasKey("thumbnailPath") ? contact.getString("thumbnailPath") : null;
 
         ReadableArray phoneNumbers = contact.hasKey("phoneNumbers") ? contact.getArray("phoneNumbers") : null;

--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsProvider.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsProvider.java
@@ -312,6 +312,11 @@ public class ContactsProvider {
                     }
                     contact.phones.add(new Contact.Item(label, phoneNumber, id));
                 }
+            } else if (mimeType.equals(Website.CONTENT_ITEM_TYPE)) {
+                String url = cursor.getString(cursor.getColumnIndex(Website.URL));
+                if (!TextUtils.isEmpty(url)) {
+                    contact.urls.add(new Contact.Item(id, url));
+                }
             } else if (mimeType.equals(Email.CONTENT_ITEM_TYPE)) {
                 String email = cursor.getString(cursor.getColumnIndex(Email.ADDRESS));
                 int type = cursor.getInt(cursor.getColumnIndex(Email.TYPE));
@@ -347,8 +352,6 @@ public class ContactsProvider {
                 contact.postalAddresses.add(new Contact.PostalAddressItem(cursor));
             } else if (mimeType.equals(Note.CONTENT_ITEM_TYPE)) {
                 contact.note = cursor.getString(cursor.getColumnIndex(Note.NOTE));
-            } else if (mimeType.equals(Website.CONTENT_ITEM_TYPE)) {
-                contact.url = cursor.getString(cursor.getColumnIndex(Website.URL));
             }else if (mimeType.equals(Event.CONTENT_ITEM_TYPE)) {
                 int eventType = cursor.getInt(cursor.getColumnIndex(Event.TYPE));
                 if (eventType == Event.TYPE_BIRTHDAY) {
@@ -421,7 +424,7 @@ public class ContactsProvider {
         private String jobTitle = "";
         private String department = "";
         private String note ="";
-        private String url ="";
+        private List<Item> urls = new ArrayList<>();
         private boolean hasPhoto = false;
         private String photoUri;
         private List<Item> emails = new ArrayList<>();
@@ -447,7 +450,6 @@ public class ContactsProvider {
             contact.putString("jobTitle", jobTitle);
             contact.putString("department", department);
             contact.putString("note", note);
-            contact.putString("url", url);
             contact.putBoolean("hasThumbnail", this.hasPhoto);
             contact.putString("thumbnailPath", photoUri == null ? "" : photoUri);
 
@@ -460,6 +462,15 @@ public class ContactsProvider {
                 phoneNumbers.pushMap(map);
             }
             contact.putArray("phoneNumbers", phoneNumbers);
+
+            WritableArray urlAddresses = Arguments.createArray();
+            for (Item item : urls) {
+                WritableMap map = Arguments.createMap();
+                map.putString("url", item.value);
+                map.putString("id", item.id);
+                urlAddresses.pushMap(map);
+            }
+            contact.putArray("urlAddresses", urlAddresses);
 
             WritableArray emailAddresses = Arguments.createArray();
             for (Item item : emails) {

--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsProvider.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsProvider.java
@@ -24,6 +24,8 @@ import static android.provider.ContactsContract.CommonDataKinds.Event;
 import static android.provider.ContactsContract.CommonDataKinds.Organization;
 import static android.provider.ContactsContract.CommonDataKinds.Phone;
 import static android.provider.ContactsContract.CommonDataKinds.StructuredName;
+import static android.provider.ContactsContract.CommonDataKinds.Note;
+import static android.provider.ContactsContract.CommonDataKinds.Website;
 import static android.provider.ContactsContract.CommonDataKinds.StructuredPostal;
 
 public class ContactsProvider {
@@ -63,6 +65,8 @@ public class ContactsProvider {
         add(StructuredPostal.REGION);
         add(StructuredPostal.POSTCODE);
         add(StructuredPostal.COUNTRY);
+        add(Note.NOTE);
+        add(Website.URL);
         add(Event.START_DATE);
         add(Event.TYPE);
     }};
@@ -189,8 +193,22 @@ public class ContactsProvider {
             Cursor cursor = contentResolver.query(
                     ContactsContract.Data.CONTENT_URI,
                     FULL_PROJECTION.toArray(new String[FULL_PROJECTION.size()]),
-                    ContactsContract.Data.MIMETYPE + "=? OR " + ContactsContract.Data.MIMETYPE + "=? OR " + ContactsContract.Data.MIMETYPE + "=? OR " + ContactsContract.Data.MIMETYPE + "=? OR " + ContactsContract.Data.MIMETYPE + "=? OR " + ContactsContract.Data.MIMETYPE + "=?",
-                    new String[]{Email.CONTENT_ITEM_TYPE, Phone.CONTENT_ITEM_TYPE, StructuredName.CONTENT_ITEM_TYPE, Organization.CONTENT_ITEM_TYPE, StructuredPostal.CONTENT_ITEM_TYPE, Event.CONTENT_ITEM_TYPE},
+                    ContactsContract.Data.MIMETYPE + "=? OR "
+                    + ContactsContract.Data.MIMETYPE + "=? OR "
+                    + ContactsContract.Data.MIMETYPE + "=? OR "
+                    + ContactsContract.Data.MIMETYPE + "=? OR "
+                    + ContactsContract.Data.MIMETYPE + "=? OR "
+                    + ContactsContract.Data.MIMETYPE + "=? OR "
+                    + ContactsContract.Data.MIMETYPE + "=?",
+                    new String[]{
+                        Email.CONTENT_ITEM_TYPE,
+                        Phone.CONTENT_ITEM_TYPE,
+                        StructuredName.CONTENT_ITEM_TYPE,
+                        Organization.CONTENT_ITEM_TYPE,
+                        StructuredPostal.CONTENT_ITEM_TYPE,
+                        Note.CONTENT_ITEM_TYPE,
+                        Website.CONTENT_ITEM_TYPE,
+                    },
                     null
             );
 
@@ -327,7 +345,11 @@ public class ContactsProvider {
                 contact.department = cursor.getString(cursor.getColumnIndex(Organization.DEPARTMENT));
             } else if (mimeType.equals(StructuredPostal.CONTENT_ITEM_TYPE)) {
                 contact.postalAddresses.add(new Contact.PostalAddressItem(cursor));
-            } else if (mimeType.equals(Event.CONTENT_ITEM_TYPE)) {
+            } else if (mimeType.equals(Note.CONTENT_ITEM_TYPE)) {
+                contact.note = cursor.getString(cursor.getColumnIndex(Note.NOTE));
+            } else if (mimeType.equals(Website.CONTENT_ITEM_TYPE)) {
+                contact.url = cursor.getString(cursor.getColumnIndex(Website.URL));
+            }else if (mimeType.equals(Event.CONTENT_ITEM_TYPE)) {
                 int eventType = cursor.getInt(cursor.getColumnIndex(Event.TYPE));
                 if (eventType == Event.TYPE_BIRTHDAY) {
                     try {
@@ -398,6 +420,8 @@ public class ContactsProvider {
         private String company = "";
         private String jobTitle = "";
         private String department = "";
+        private String note ="";
+        private String url ="";
         private boolean hasPhoto = false;
         private String photoUri;
         private List<Item> emails = new ArrayList<>();
@@ -422,6 +446,8 @@ public class ContactsProvider {
             contact.putString("company", company);
             contact.putString("jobTitle", jobTitle);
             contact.putString("department", department);
+            contact.putString("note", note);
+            contact.putString("url", url);
             contact.putBoolean("hasThumbnail", this.hasPhoto);
             contact.putString("thumbnailPath", photoUri == null ? "" : photoUri);
 

--- a/ios/RCTContacts/RCTContacts.m
+++ b/ios/RCTContacts/RCTContacts.m
@@ -63,6 +63,8 @@ RCT_EXPORT_METHOD(getContactsMatchingString:(NSString *)string callback:(RCTResp
                       CNContactOrganizationNameKey,
                       CNContactJobTitleKey,
                       CNContactImageDataAvailableKey,
+                      CNContactNoteKey,
+                      CNSocialProfileURLStringKey,
                       CNContactBirthdayKey
                       ];
     NSArray *arrayOfContacts = [store unifiedContactsMatchingPredicate:[CNContact predicateForContactsMatchingName:searchString]
@@ -143,6 +145,8 @@ RCT_EXPORT_METHOD(getAllWithoutPhotos:(RCTResponseSenderBlock) callback)
     NSString *middleName = person.middleName;
     NSString *company = person.organizationName;
     NSString *jobTitle = person.jobTitle;
+    NSString *note = person.note;
+    NSString *url = person.url;
     NSDateComponents *birthday = person.birthday;
     
     [output setObject:recordID forKey: @"recordID"];
@@ -167,7 +171,14 @@ RCT_EXPORT_METHOD(getAllWithoutPhotos:(RCTResponseSenderBlock) callback)
         [output setObject: (jobTitle) ? jobTitle : @"" forKey:@"jobTitle"];
     }
 
-    
+    if(note){
+        [output setObject: (note) ? note : @"" forKey:@"note"];
+    }
+
+    if(url){
+        [output setObject: (url) ? url : @"" forKey:@"url"];
+    }
+
     if (birthday) {
         if (birthday.month != NSDateComponentUndefined && birthday.day != NSDateComponentUndefined) {
             //months are indexed to 0 in JavaScript (0 = January) so we subtract 1 from NSDateComponents.month
@@ -425,6 +436,8 @@ RCT_EXPORT_METHOD(updateContact:(NSDictionary *)contactData callback:(RCTRespons
                              CNContactImageDataAvailableKey,
                              CNContactThumbnailImageDataKey,
                              CNContactImageDataKey,
+                             CNContactNoteKey,
+                             CNSocialProfileURLStringKey,
                              CNContactBirthdayKey
                              ];
 
@@ -452,6 +465,8 @@ RCT_EXPORT_METHOD(updateContact:(NSDictionary *)contactData callback:(RCTRespons
     NSString *middleName = [contactData valueForKey:@"middleName"];
     NSString *company = [contactData valueForKey:@"company"];
     NSString *jobTitle = [contactData valueForKey:@"jobTitle"];
+    NSString *note = [contactData valueForKey:@"note"];
+    NSString *url = [contactData valueForKey:@"url"];
     NSDictionary *birthday = [contactData valueForKey:@"birthday"];
     
     contact.givenName = givenName;
@@ -459,6 +474,8 @@ RCT_EXPORT_METHOD(updateContact:(NSDictionary *)contactData callback:(RCTRespons
     contact.middleName = middleName;
     contact.organizationName = company;
     contact.jobTitle = jobTitle;
+    contact.note = note;
+    contact.url = url;
     
     if (birthday) {
         NSDateComponents *components;


### PR DESCRIPTION
Addresses issue #310: Add support for Websites/ URLs for contact creation(https://github.com/rt2zz/react-native-contacts/issues/310)

Adds new URL functionality and incorporates support for Notes from previous PR's that currently have merge conflicts:

- added "note" property [#188](https://github.com/rt2zz/react-native-contacts/pull/188)
- Added support for Note field in iOS [#154](https://github.com/rt2zz/react-native-contacts/pull/154)

Brief description:
- Adds url and note functionality for both iOS and Android
- Users will now see url and note information when pulling in contacts (see example in README)
- Test additions here have been added to /morenoh149/react-native-contacts-test [#8] (https://github.com/morenoh149/react-native-contacts-test/pull/8)