### PR TITLE
updateContact update phone numbers and emails instead of insert [Android]

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,6 @@ Update reference contacts by their recordID (as returned by the OS in getContact
 There are issues with updating contacts on Android:
 1. custom labels get overwritten to "Other",
 1. postal address update code doesn't exist. (it exists for addContact)
-1. phoneNumbers and emails insert instead of update.
 See https://github.com/rt2zz/react-native-contacts/issues/332#issuecomment-455675041 for current discussions.
 
 ## Delete Contacts

--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
@@ -799,7 +799,7 @@ public class ContactsManager extends ReactContextBaseJavaModule {
                 emailType = CommonDataKinds.Email.TYPE_MOBILE;
                 break;
             default:
-                emailType = CommonDataKinds.Email.TYPE_CUSTOM;
+                emailType = CommonDataKinds.Email.TYPE_OTHER;
                 break;
         }
         return emailType;

--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
@@ -581,6 +581,7 @@ public class ContactsManager extends ReactContextBaseJavaModule {
                 );
         ops.add(op.build());
         
+        // add passed phonenumbers
         for (int i = 0; i < numOfPhones; i++) {
             op = ContentProviderOperation.newInsert(ContactsContract.Data.CONTENT_URI)
                     .withValue(ContactsContract.Data.RAW_CONTACT_ID, String.valueOf(rawContactId))
@@ -612,9 +613,11 @@ public class ContactsManager extends ReactContextBaseJavaModule {
                 );
         ops.add(op.build());
 
+        // add passed email addresses
         for (int i = 0; i < numOfEmails; i++) {
-            op = ContentProviderOperation.newUpdate(ContactsContract.Data.CONTENT_URI)
-                    .withSelection(ContactsContract.Data._ID + "=?", new String[]{String.valueOf(emailIds[i])})
+            op = ContentProviderOperation.newInsert(ContactsContract.Data.CONTENT_URI)
+                    .withValue(ContactsContract.Data.RAW_CONTACT_ID, String.valueOf(rawContactId))
+                    .withValue(ContactsContract.Data.MIMETYPE, CommonDataKinds.Email.CONTENT_ITEM_TYPE)
                     .withValue(CommonDataKinds.Email.ADDRESS, emails[i])
                     .withValue(CommonDataKinds.Email.TYPE, emailsLabels[i]);
             ops.add(op.build());
@@ -796,7 +799,7 @@ public class ContactsManager extends ReactContextBaseJavaModule {
                 emailType = CommonDataKinds.Email.TYPE_MOBILE;
                 break;
             default:
-                emailType = CommonDataKinds.Email.TYPE_OTHER;
+                emailType = CommonDataKinds.Email.TYPE_CUSTOM;
                 break;
         }
         return emailType;

--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
@@ -474,7 +474,7 @@ public class ContactsManager extends ReactContextBaseJavaModule {
      */
     @ReactMethod
     public void updateContact(ReadableMap contact, Callback callback) {
-
+        
         String recordID = contact.hasKey("recordID") ? contact.getString("recordID") : null;
         String rawContactId = contact.hasKey("rawContactId") ? contact.getString("rawContactId") : null;
 
@@ -610,6 +610,14 @@ public class ContactsManager extends ReactContextBaseJavaModule {
             }
             ops.add(op.build());
         }
+
+        // remove existing emails first
+        op = ContentProviderOperation.newDelete(ContactsContract.Data.CONTENT_URI)
+                .withSelection(
+                    ContactsContract.Data.MIMETYPE  + "=? AND "+ ContactsContract.Data.CONTACT_ID + " = ?", 
+                    new String[]{String.valueOf(CommonDataKinds.Email.CONTENT_ITEM_TYPE), String.valueOf(recordID)}
+                );
+        ops.add(op.build());
 
         for (int i = 0; i < numOfEmails; i++) {
             if (emailIds[i] == null) {

--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
@@ -582,18 +582,11 @@ public class ContactsManager extends ReactContextBaseJavaModule {
         ops.add(op.build());
         
         for (int i = 0; i < numOfPhones; i++) {
-            if (phoneIds[i] == null) {
-                op = ContentProviderOperation.newInsert(ContactsContract.Data.CONTENT_URI)
-                        .withValue(ContactsContract.Data.RAW_CONTACT_ID, String.valueOf(rawContactId))
-                        .withValue(ContactsContract.Data.MIMETYPE, CommonDataKinds.Phone.CONTENT_ITEM_TYPE)
-                        .withValue(CommonDataKinds.Phone.NUMBER, phones[i])
-                        .withValue(CommonDataKinds.Phone.TYPE, phonesLabels[i]);
-            } else {
-                op = ContentProviderOperation.newUpdate(ContactsContract.Data.CONTENT_URI)
-                        .withSelection(ContactsContract.Data._ID + "=?", new String[]{String.valueOf(phoneIds[i])})
-                        .withValue(CommonDataKinds.Phone.NUMBER, phones[i])
-                        .withValue(CommonDataKinds.Phone.TYPE, phonesLabels[i]);
-            }
+            op = ContentProviderOperation.newInsert(ContactsContract.Data.CONTENT_URI)
+                    .withValue(ContactsContract.Data.RAW_CONTACT_ID, String.valueOf(rawContactId))
+                    .withValue(ContactsContract.Data.MIMETYPE, CommonDataKinds.Phone.CONTENT_ITEM_TYPE)
+                    .withValue(CommonDataKinds.Phone.NUMBER, phones[i])
+                    .withValue(CommonDataKinds.Phone.TYPE, phonesLabels[i]);
             ops.add(op.build());
         }
 
@@ -620,18 +613,10 @@ public class ContactsManager extends ReactContextBaseJavaModule {
         ops.add(op.build());
 
         for (int i = 0; i < numOfEmails; i++) {
-            if (emailIds[i] == null) {
-                op = ContentProviderOperation.newInsert(ContactsContract.Data.CONTENT_URI)
-                        .withValue(ContactsContract.Data.RAW_CONTACT_ID, String.valueOf(rawContactId))
-                        .withValue(ContactsContract.Data.MIMETYPE, CommonDataKinds.Email.CONTENT_ITEM_TYPE)
-                        .withValue(CommonDataKinds.Email.ADDRESS, emails[i])
-                        .withValue(CommonDataKinds.Email.TYPE, emailsLabels[i]);
-            } else {
-                op = ContentProviderOperation.newUpdate(ContactsContract.Data.CONTENT_URI)
-                        .withSelection(ContactsContract.Data._ID + "=?", new String[]{String.valueOf(emailIds[i])})
-                        .withValue(CommonDataKinds.Email.ADDRESS, emails[i])
-                        .withValue(CommonDataKinds.Email.TYPE, emailsLabels[i]);
-            }
+            op = ContentProviderOperation.newUpdate(ContactsContract.Data.CONTENT_URI)
+                    .withSelection(ContactsContract.Data._ID + "=?", new String[]{String.valueOf(emailIds[i])})
+                    .withValue(CommonDataKinds.Email.ADDRESS, emails[i])
+                    .withValue(CommonDataKinds.Email.TYPE, emailsLabels[i]);
             ops.add(op.build());
         }
 

--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
@@ -573,6 +573,14 @@ public class ContactsManager extends ReactContextBaseJavaModule {
 
         op.withYieldAllowed(true);
 
+        // remove existing phoneNumbers first
+        op = ContentProviderOperation.newDelete(ContactsContract.Data.CONTENT_URI)
+                .withSelection(
+                    ContactsContract.Data.MIMETYPE  + "=? AND "+ ContactsContract.Data.CONTACT_ID + " = ?", 
+                    new String[]{String.valueOf(CommonDataKinds.Phone.CONTENT_ITEM_TYPE), String.valueOf(recordID)}
+                );
+        ops.add(op.build());
+        
         for (int i = 0; i < numOfPhones; i++) {
             if (phoneIds[i] == null) {
                 op = ContentProviderOperation.newInsert(ContactsContract.Data.CONTENT_URI)


### PR DESCRIPTION
I encountered an issue where when calling `updateContact` on android, it would insert the phone numbers and emails leading to multiple duplicates, essentially the same issue as #332.

The expected behaviour is now consistent with iOS. If you call updateContact with the new contact information, instead of inserting the email addresses and phone numbers (leading to duplicates), it now actually updates them.