### PR TITLE
[Android] Several Fixes with updateContact

### DIFF
--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
@@ -314,15 +314,18 @@ public class ContactsManager extends ReactContextBaseJavaModule {
         ReadableArray phoneNumbers = contact.hasKey("phoneNumbers") ? contact.getArray("phoneNumbers") : null;
         int numOfPhones = 0;
         String[] phones = null;
-        Integer[] phonesLabels = null;
+        Integer[] phonesTypes = null;
+		String[] phonesLabels = null;
         if (phoneNumbers != null) {
             numOfPhones = phoneNumbers.size();
             phones = new String[numOfPhones];
-            phonesLabels = new Integer[numOfPhones];
+            phonesTypes = new Integer[numOfPhones];
+			phonesLabels = new String[numOfPhones];
             for (int i = 0; i < numOfPhones; i++) {
                 phones[i] = phoneNumbers.getMap(i).getString("number");
                 String label = phoneNumbers.getMap(i).getString("label");
-                phonesLabels[i] = mapStringToPhoneType(label);
+                phonesTypes[i] = mapStringToPhoneType(label);
+				phonesLabels[i] = label;
             }
         }
 
@@ -340,15 +343,18 @@ public class ContactsManager extends ReactContextBaseJavaModule {
         ReadableArray emailAddresses = contact.hasKey("emailAddresses") ? contact.getArray("emailAddresses") : null;
         int numOfEmails = 0;
         String[] emails = null;
-        Integer[] emailsLabels = null;
+        Integer[] emailsTypes = null;
+		String[] emailsLabels = null;
         if (emailAddresses != null) {
             numOfEmails = emailAddresses.size();
             emails = new String[numOfEmails];
-            emailsLabels = new Integer[numOfEmails];
+            emailsTypes = new Integer[numOfEmails];
+			emailsLabels = new String[numOfEmails];
             for (int i = 0; i < numOfEmails; i++) {
                 emails[i] = emailAddresses.getMap(i).getString("email");
                 String label = emailAddresses.getMap(i).getString("label");
-                emailsLabels[i] = mapStringToEmailType(label);
+                emailsTypes[i] = mapStringToEmailType(label);
+				emailsLabels[i] = label;
             }
         }
 
@@ -392,7 +398,8 @@ public class ContactsManager extends ReactContextBaseJavaModule {
                     .withValueBackReference(ContactsContract.Data.RAW_CONTACT_ID, 0)
                     .withValue(ContactsContract.Data.MIMETYPE, CommonDataKinds.Phone.CONTENT_ITEM_TYPE)
                     .withValue(CommonDataKinds.Phone.NUMBER, phones[i])
-                    .withValue(CommonDataKinds.Phone.TYPE, phonesLabels[i]);
+                    .withValue(CommonDataKinds.Phone.TYPE, phonesTypes[i])
+					.withValue(CommonDataKinds.Phone.LABEL, phonesLabels[i]);
             ops.add(op.build());
         }
 
@@ -409,7 +416,8 @@ public class ContactsManager extends ReactContextBaseJavaModule {
                     .withValueBackReference(ContactsContract.Data.RAW_CONTACT_ID, 0)
                     .withValue(ContactsContract.Data.MIMETYPE, CommonDataKinds.Email.CONTENT_ITEM_TYPE)
                     .withValue(CommonDataKinds.Email.ADDRESS, emails[i])
-                    .withValue(CommonDataKinds.Email.TYPE, emailsLabels[i]);
+                    .withValue(CommonDataKinds.Email.TYPE, emailsTypes[i])
+					.withValue(CommonDataKinds.Email.LABEL, emailsLabels[i]);
             ops.add(op.build());
         }
 
@@ -434,6 +442,7 @@ public class ContactsManager extends ReactContextBaseJavaModule {
                         .withValueBackReference(ContactsContract.Data.RAW_CONTACT_ID, 0)
                         .withValue(ContactsContract.Data.MIMETYPE, CommonDataKinds.StructuredPostal.CONTENT_ITEM_TYPE)
                         .withValue(CommonDataKinds.StructuredPostal.TYPE, mapStringToPostalAddressType(address.getString("label")))
+						.withValue(CommonDataKinds.StructuredPostal.LABEL, address.getString("label"))
                         .withValue(CommonDataKinds.StructuredPostal.STREET, address.getString("street"))
                         .withValue(CommonDataKinds.StructuredPostal.CITY, address.getString("city"))
                         .withValue(CommonDataKinds.StructuredPostal.REGION, address.getString("state"))
@@ -492,12 +501,14 @@ public class ContactsManager extends ReactContextBaseJavaModule {
         ReadableArray phoneNumbers = contact.hasKey("phoneNumbers") ? contact.getArray("phoneNumbers") : null;
         int numOfPhones = 0;
         String[] phones = null;
-        Integer[] phonesLabels = null;
+        Integer[] phonesTypes = null;
+		String[] phonesLabels = null;
         String[] phoneIds = null;
         if (phoneNumbers != null) {
             numOfPhones = phoneNumbers.size();
             phones = new String[numOfPhones];
-            phonesLabels = new Integer[numOfPhones];
+            phonesTypes = new Integer[numOfPhones];
+			phonesLabels = new String[numOfPhones];
             phoneIds = new String[numOfPhones];
             for (int i = 0; i < numOfPhones; i++) {
                 ReadableMap phoneMap = phoneNumbers.getMap(i);
@@ -505,7 +516,8 @@ public class ContactsManager extends ReactContextBaseJavaModule {
                 String phoneLabel = phoneMap.getString("label");
                 String phoneId = phoneMap.hasKey("id") ? phoneMap.getString("id") : null;
                 phones[i] = phoneNumber;
-                phonesLabels[i] = mapStringToPhoneType(phoneLabel);
+                phonesTypes[i] = mapStringToPhoneType(phoneLabel);
+				phonesLabels[i] = phoneLabel;
                 phoneIds[i] = phoneId;
             }
         }
@@ -529,19 +541,22 @@ public class ContactsManager extends ReactContextBaseJavaModule {
         ReadableArray emailAddresses = contact.hasKey("emailAddresses") ? contact.getArray("emailAddresses") : null;
         int numOfEmails = 0;
         String[] emails = null;
-        Integer[] emailsLabels = null;
+		Integer[] emailsTypes = null;
+        String[] emailsLabels = null;
         String[] emailIds = null;
 
         if (emailAddresses != null) {
             numOfEmails = emailAddresses.size();
             emails = new String[numOfEmails];
             emailIds = new String[numOfEmails];
-            emailsLabels = new Integer[numOfEmails];
+			emailsTypes = new Integer[numOfEmails];
+            emailsLabels = new String[numOfEmails];
             for (int i = 0; i < numOfEmails; i++) {
                 ReadableMap emailMap = emailAddresses.getMap(i);
                 emails[i] = emailMap.getString("email");
                 String label = emailMap.getString("label");
-                emailsLabels[i] = mapStringToEmailType(label);
+                emailsTypes[i] = mapStringToEmailType(label);
+				emailsLabels[i] = label;
                 emailIds[i] = emailMap.hasKey("id") ? emailMap.getString("id") : null;
             }
         }
@@ -554,7 +569,8 @@ public class ContactsManager extends ReactContextBaseJavaModule {
         String[] postalAddressesRegion = null;
         String[] postalAddressesPostCode = null;
         String[] postalAddressesCountry = null;
-        Integer[] postalAddressesLabel = null;
+        Integer[] postalAddressesType = null;
+		String[] postalAddressesLabel = null;
         if (postalAddresses != null) {
             numOfPostalAddresses = postalAddresses.size();
             postalAddressesStreet = new String[numOfPostalAddresses];
@@ -563,15 +579,18 @@ public class ContactsManager extends ReactContextBaseJavaModule {
             postalAddressesRegion = new String[numOfPostalAddresses];
             postalAddressesPostCode = new String[numOfPostalAddresses];
             postalAddressesCountry = new String[numOfPostalAddresses];
-            postalAddressesLabel = new Integer[numOfPostalAddresses];
+            postalAddressesType = new Integer[numOfPostalAddresses];
+			postalAddressesLabel = new String[numOfPostalAddresses];
             for (int i = 0; i < numOfPostalAddresses; i++) {
+				String postalLabel = postalAddresses.getMap(i).getString("label");
                 postalAddressesStreet[i] = postalAddresses.getMap(i).getString("street");
                 postalAddressesCity[i] = postalAddresses.getMap(i).getString("city");
                 postalAddressesState[i] = postalAddresses.getMap(i).getString("state");
                 postalAddressesRegion[i] = postalAddresses.getMap(i).getString("region");
                 postalAddressesPostCode[i] = postalAddresses.getMap(i).getString("postCode");
                 postalAddressesCountry[i] = postalAddresses.getMap(i).getString("country");
-                postalAddressesLabel[i] = mapStringToPostalAddressType(postalAddresses.getMap(i).getString("label"));
+                postalAddressesType[i] = mapStringToPostalAddressType(postalLabel);
+				postalAddressesLabel[i] = postalLabel;
             }
         }
 
@@ -618,7 +637,8 @@ public class ContactsManager extends ReactContextBaseJavaModule {
 						.withValue(ContactsContract.Data.RAW_CONTACT_ID, String.valueOf(rawContactId))
 						.withValue(ContactsContract.Data.MIMETYPE, CommonDataKinds.Phone.CONTENT_ITEM_TYPE)
 						.withValue(CommonDataKinds.Phone.NUMBER, phones[i])
-						.withValue(CommonDataKinds.Phone.TYPE, phonesLabels[i]);
+						.withValue(CommonDataKinds.Phone.TYPE, phonesTypes[i])
+						.withValue(CommonDataKinds.Phone.LABEL, phonesLabels[i]);
 				ops.add(op.build());
 			}
 		}
@@ -652,7 +672,8 @@ public class ContactsManager extends ReactContextBaseJavaModule {
 						.withValue(ContactsContract.Data.RAW_CONTACT_ID, String.valueOf(rawContactId))
 						.withValue(ContactsContract.Data.MIMETYPE, CommonDataKinds.Email.CONTENT_ITEM_TYPE)
 						.withValue(CommonDataKinds.Email.ADDRESS, emails[i])
-						.withValue(CommonDataKinds.Email.TYPE, emailsLabels[i]);
+						.withValue(CommonDataKinds.Email.TYPE, emailsTypes[i])
+						.withValue(CommonDataKinds.Email.LABEL, emailsLabels[i]);
 				ops.add(op.build());
 			}
 		}
@@ -682,7 +703,8 @@ public class ContactsManager extends ReactContextBaseJavaModule {
                 op = ContentProviderOperation.newInsert(ContactsContract.Data.CONTENT_URI)
                         .withValue(ContactsContract.Data.RAW_CONTACT_ID, String.valueOf(rawContactId))
                         .withValue(ContactsContract.Data.MIMETYPE, CommonDataKinds.StructuredPostal.CONTENT_ITEM_TYPE)
-                        .withValue(CommonDataKinds.StructuredPostal.TYPE, postalAddressesLabel[i])
+                        .withValue(CommonDataKinds.StructuredPostal.TYPE, postalAddressesType[i])
+						.withValue(CommonDataKinds.StructuredPostal.LABEL, postalAddressesLabel[i])
                         .withValue(CommonDataKinds.StructuredPostal.STREET, postalAddressesStreet[i])
                         .withValue(CommonDataKinds.StructuredPostal.CITY, postalAddressesCity[i])
                         .withValue(CommonDataKinds.StructuredPostal.REGION, postalAddressesState[i])
@@ -815,8 +837,26 @@ public class ContactsManager extends ReactContextBaseJavaModule {
             case "mobile":
                 phoneType = CommonDataKinds.Phone.TYPE_MOBILE;
                 break;
+			case "main":
+				phoneType = CommonDataKinds.Phone.TYPE_MAIN;
+				break;
+			case "work fax":
+				phoneType = CommonDataKinds.Phone.TYPE_FAX_WORK;
+				break;
+			case "home fax":
+				phoneType = CommonDataKinds.Phone.TYPE_FAX_HOME;
+				break;
+			case "pager":
+				phoneType = CommonDataKinds.Phone.TYPE_PAGER;
+				break;
+			case "work_pager":
+				phoneType = CommonDataKinds.Phone.TYPE_WORK_PAGER;
+				break;
+			case "work_mobile":
+				phoneType = CommonDataKinds.Phone.TYPE_WORK_MOBILE;
+				break;
             default:
-                phoneType = CommonDataKinds.Phone.TYPE_OTHER;
+                phoneType = CommonDataKinds.Phone.TYPE_CUSTOM;
                 break;
         }
         return phoneType;
@@ -839,7 +879,7 @@ public class ContactsManager extends ReactContextBaseJavaModule {
                 emailType = CommonDataKinds.Email.TYPE_MOBILE;
                 break;
             default:
-                emailType = CommonDataKinds.Email.TYPE_OTHER;
+                emailType = CommonDataKinds.Email.TYPE_CUSTOM;
                 break;
         }
         return emailType;
@@ -855,7 +895,7 @@ public class ContactsManager extends ReactContextBaseJavaModule {
                 postalAddressType = CommonDataKinds.StructuredPostal.TYPE_WORK;
                 break;
             default:
-                postalAddressType = CommonDataKinds.StructuredPostal.TYPE_OTHER;
+                postalAddressType = CommonDataKinds.StructuredPostal.TYPE_CUSTOM;
                 break;
         }
         return postalAddressType;

--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
@@ -315,17 +315,17 @@ public class ContactsManager extends ReactContextBaseJavaModule {
         int numOfPhones = 0;
         String[] phones = null;
         Integer[] phonesTypes = null;
-		String[] phonesLabels = null;
+        String[] phonesLabels = null;
         if (phoneNumbers != null) {
             numOfPhones = phoneNumbers.size();
             phones = new String[numOfPhones];
             phonesTypes = new Integer[numOfPhones];
-			phonesLabels = new String[numOfPhones];
+            phonesLabels = new String[numOfPhones];
             for (int i = 0; i < numOfPhones; i++) {
                 phones[i] = phoneNumbers.getMap(i).getString("number");
                 String label = phoneNumbers.getMap(i).getString("label");
                 phonesTypes[i] = mapStringToPhoneType(label);
-				phonesLabels[i] = label;
+                phonesLabels[i] = label;
             }
         }
 
@@ -344,7 +344,7 @@ public class ContactsManager extends ReactContextBaseJavaModule {
         int numOfEmails = 0;
         String[] emails = null;
         Integer[] emailsTypes = null;
-		String[] emailsLabels = null;
+        String[] emailsLabels = null;
         if (emailAddresses != null) {
             numOfEmails = emailAddresses.size();
             emails = new String[numOfEmails];
@@ -354,7 +354,7 @@ public class ContactsManager extends ReactContextBaseJavaModule {
                 emails[i] = emailAddresses.getMap(i).getString("email");
                 String label = emailAddresses.getMap(i).getString("label");
                 emailsTypes[i] = mapStringToEmailType(label);
-				emailsLabels[i] = label;
+                emailsLabels[i] = label;
             }
         }
 
@@ -502,13 +502,13 @@ public class ContactsManager extends ReactContextBaseJavaModule {
         int numOfPhones = 0;
         String[] phones = null;
         Integer[] phonesTypes = null;
-		String[] phonesLabels = null;
+        String[] phonesLabels = null;
         String[] phoneIds = null;
         if (phoneNumbers != null) {
             numOfPhones = phoneNumbers.size();
             phones = new String[numOfPhones];
             phonesTypes = new Integer[numOfPhones];
-			phonesLabels = new String[numOfPhones];
+            phonesLabels = new String[numOfPhones];
             phoneIds = new String[numOfPhones];
             for (int i = 0; i < numOfPhones; i++) {
                 ReadableMap phoneMap = phoneNumbers.getMap(i);
@@ -517,7 +517,7 @@ public class ContactsManager extends ReactContextBaseJavaModule {
                 String phoneId = phoneMap.hasKey("id") ? phoneMap.getString("id") : null;
                 phones[i] = phoneNumber;
                 phonesTypes[i] = mapStringToPhoneType(phoneLabel);
-				phonesLabels[i] = phoneLabel;
+                phonesLabels[i] = phoneLabel;
                 phoneIds[i] = phoneId;
             }
         }
@@ -561,7 +561,7 @@ public class ContactsManager extends ReactContextBaseJavaModule {
             }
         }
 
-		ReadableArray postalAddresses = contact.hasKey("postalAddresses") ? contact.getArray("postalAddresses") : null;
+        ReadableArray postalAddresses = contact.hasKey("postalAddresses") ? contact.getArray("postalAddresses") : null;
         int numOfPostalAddresses = 0;
         String[] postalAddressesStreet = null;
         String[] postalAddressesCity = null;
@@ -570,7 +570,7 @@ public class ContactsManager extends ReactContextBaseJavaModule {
         String[] postalAddressesPostCode = null;
         String[] postalAddressesCountry = null;
         Integer[] postalAddressesType = null;
-		String[] postalAddressesLabel = null;
+        String[] postalAddressesLabel = null;
         if (postalAddresses != null) {
             numOfPostalAddresses = postalAddresses.size();
             postalAddressesStreet = new String[numOfPostalAddresses];
@@ -580,7 +580,7 @@ public class ContactsManager extends ReactContextBaseJavaModule {
             postalAddressesPostCode = new String[numOfPostalAddresses];
             postalAddressesCountry = new String[numOfPostalAddresses];
             postalAddressesType = new Integer[numOfPostalAddresses];
-			postalAddressesLabel = new String[numOfPostalAddresses];
+            postalAddressesLabel = new String[numOfPostalAddresses];
             for (int i = 0; i < numOfPostalAddresses; i++) {
 				String postalLabel = postalAddresses.getMap(i).getString("label");
                 postalAddressesStreet[i] = postalAddresses.getMap(i).getString("street");
@@ -590,7 +590,7 @@ public class ContactsManager extends ReactContextBaseJavaModule {
                 postalAddressesPostCode[i] = postalAddresses.getMap(i).getString("postCode");
                 postalAddressesCountry[i] = postalAddresses.getMap(i).getString("country");
                 postalAddressesType[i] = mapStringToPostalAddressType(postalLabel);
-				postalAddressesLabel[i] = postalLabel;
+                postalAddressesLabel[i] = postalLabel;
             }
         }
 

--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
@@ -602,23 +602,26 @@ public class ContactsManager extends ReactContextBaseJavaModule {
 
         op.withYieldAllowed(true);
 
-        // remove existing phoneNumbers first
-        op = ContentProviderOperation.newDelete(ContactsContract.Data.CONTENT_URI)
-                .withSelection(
-                    ContactsContract.Data.MIMETYPE  + "=? AND "+ ContactsContract.Data.CONTACT_ID + " = ?", 
-                    new String[]{String.valueOf(CommonDataKinds.Phone.CONTENT_ITEM_TYPE), String.valueOf(recordID)}
-                );
-        ops.add(op.build());
-        
-        // add passed phonenumbers
-        for (int i = 0; i < numOfPhones; i++) {
-            op = ContentProviderOperation.newInsert(ContactsContract.Data.CONTENT_URI)
-                    .withValue(ContactsContract.Data.RAW_CONTACT_ID, String.valueOf(rawContactId))
-                    .withValue(ContactsContract.Data.MIMETYPE, CommonDataKinds.Phone.CONTENT_ITEM_TYPE)
-                    .withValue(CommonDataKinds.Phone.NUMBER, phones[i])
-                    .withValue(CommonDataKinds.Phone.TYPE, phonesLabels[i]);
-            ops.add(op.build());
-        }
+		
+        if (phoneNumbers != null) {		
+			// remove existing phoneNumbers first
+			op = ContentProviderOperation.newDelete(ContactsContract.Data.CONTENT_URI)
+					.withSelection(
+						ContactsContract.Data.MIMETYPE  + "=? AND "+ ContactsContract.Data.RAW_CONTACT_ID + " = ?", 
+						new String[]{String.valueOf(CommonDataKinds.Phone.CONTENT_ITEM_TYPE), String.valueOf(rawContactId)}
+					);
+			ops.add(op.build());
+			
+			// add passed phonenumbers
+			for (int i = 0; i < numOfPhones; i++) {
+				op = ContentProviderOperation.newInsert(ContactsContract.Data.CONTENT_URI)
+						.withValue(ContactsContract.Data.RAW_CONTACT_ID, String.valueOf(rawContactId))
+						.withValue(ContactsContract.Data.MIMETYPE, CommonDataKinds.Phone.CONTENT_ITEM_TYPE)
+						.withValue(CommonDataKinds.Phone.NUMBER, phones[i])
+						.withValue(CommonDataKinds.Phone.TYPE, phonesLabels[i]);
+				ops.add(op.build());
+			}
+		}
 
         for (int i = 0; i < numOfUrls; i++) {
             if (urlIds[i] == null) {
@@ -634,23 +637,25 @@ public class ContactsManager extends ReactContextBaseJavaModule {
             ops.add(op.build());
         }
 
-        // remove existing emails first
-        op = ContentProviderOperation.newDelete(ContactsContract.Data.CONTENT_URI)
-                .withSelection(
-                    ContactsContract.Data.MIMETYPE  + "=? AND "+ ContactsContract.Data.CONTACT_ID + " = ?", 
-                    new String[]{String.valueOf(CommonDataKinds.Email.CONTENT_ITEM_TYPE), String.valueOf(recordID)}
-                );
-        ops.add(op.build());
+		if (emailAddresses != null){
+			// remove existing emails first
+			op = ContentProviderOperation.newDelete(ContactsContract.Data.CONTENT_URI)
+					.withSelection(
+						ContactsContract.Data.MIMETYPE  + "=? AND "+ ContactsContract.Data.RAW_CONTACT_ID + " = ?", 
+						new String[]{String.valueOf(CommonDataKinds.Email.CONTENT_ITEM_TYPE), String.valueOf(rawContactId)}
+					);
+			ops.add(op.build());
 
-        // add passed email addresses
-        for (int i = 0; i < numOfEmails; i++) {
-            op = ContentProviderOperation.newInsert(ContactsContract.Data.CONTENT_URI)
-                    .withValue(ContactsContract.Data.RAW_CONTACT_ID, String.valueOf(rawContactId))
-                    .withValue(ContactsContract.Data.MIMETYPE, CommonDataKinds.Email.CONTENT_ITEM_TYPE)
-                    .withValue(CommonDataKinds.Email.ADDRESS, emails[i])
-                    .withValue(CommonDataKinds.Email.TYPE, emailsLabels[i]);
-            ops.add(op.build());
-        }
+			// add passed email addresses
+			for (int i = 0; i < numOfEmails; i++) {
+				op = ContentProviderOperation.newInsert(ContactsContract.Data.CONTENT_URI)
+						.withValue(ContactsContract.Data.RAW_CONTACT_ID, String.valueOf(rawContactId))
+						.withValue(ContactsContract.Data.MIMETYPE, CommonDataKinds.Email.CONTENT_ITEM_TYPE)
+						.withValue(CommonDataKinds.Email.ADDRESS, emails[i])
+						.withValue(CommonDataKinds.Email.TYPE, emailsLabels[i]);
+				ops.add(op.build());
+			}
+		}
 
          if(thumbnailPath != null && !thumbnailPath.isEmpty()) {
             Bitmap photo = BitmapFactory.decodeFile(thumbnailPath);
@@ -668,8 +673,8 @@ public class ContactsManager extends ReactContextBaseJavaModule {
 			//remove existing addresses
 			 op = ContentProviderOperation.newDelete(ContactsContract.Data.CONTENT_URI)
 					.withSelection(
-						ContactsContract.Data.MIMETYPE  + "=? AND "+ ContactsContract.Data.CONTACT_ID + " = ?", 
-						new String[]{String.valueOf(CommonDataKinds.StructuredPostal.CONTENT_ITEM_TYPE), String.valueOf(recordID)}
+						ContactsContract.Data.MIMETYPE  + "=? AND "+ ContactsContract.Data.RAW_CONTACT_ID + " = ?", 
+						new String[]{String.valueOf(CommonDataKinds.StructuredPostal.CONTENT_ITEM_TYPE), String.valueOf(rawContactId)}
 					);
        		ops.add(op.build());
 

--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
@@ -349,7 +349,7 @@ public class ContactsManager extends ReactContextBaseJavaModule {
             numOfEmails = emailAddresses.size();
             emails = new String[numOfEmails];
             emailsTypes = new Integer[numOfEmails];
-			emailsLabels = new String[numOfEmails];
+            emailsLabels = new String[numOfEmails];
             for (int i = 0; i < numOfEmails; i++) {
                 emails[i] = emailAddresses.getMap(i).getString("email");
                 String label = emailAddresses.getMap(i).getString("label");
@@ -399,7 +399,7 @@ public class ContactsManager extends ReactContextBaseJavaModule {
                     .withValue(ContactsContract.Data.MIMETYPE, CommonDataKinds.Phone.CONTENT_ITEM_TYPE)
                     .withValue(CommonDataKinds.Phone.NUMBER, phones[i])
                     .withValue(CommonDataKinds.Phone.TYPE, phonesTypes[i])
-					.withValue(CommonDataKinds.Phone.LABEL, phonesLabels[i]);
+                    .withValue(CommonDataKinds.Phone.LABEL, phonesLabels[i]);
             ops.add(op.build());
         }
 
@@ -417,7 +417,7 @@ public class ContactsManager extends ReactContextBaseJavaModule {
                     .withValue(ContactsContract.Data.MIMETYPE, CommonDataKinds.Email.CONTENT_ITEM_TYPE)
                     .withValue(CommonDataKinds.Email.ADDRESS, emails[i])
                     .withValue(CommonDataKinds.Email.TYPE, emailsTypes[i])
-					.withValue(CommonDataKinds.Email.LABEL, emailsLabels[i]);
+                    .withValue(CommonDataKinds.Email.LABEL, emailsLabels[i]);
             ops.add(op.build());
         }
 
@@ -442,7 +442,7 @@ public class ContactsManager extends ReactContextBaseJavaModule {
                         .withValueBackReference(ContactsContract.Data.RAW_CONTACT_ID, 0)
                         .withValue(ContactsContract.Data.MIMETYPE, CommonDataKinds.StructuredPostal.CONTENT_ITEM_TYPE)
                         .withValue(CommonDataKinds.StructuredPostal.TYPE, mapStringToPostalAddressType(address.getString("label")))
-						.withValue(CommonDataKinds.StructuredPostal.LABEL, address.getString("label"))
+                        .withValue(CommonDataKinds.StructuredPostal.LABEL, address.getString("label"))
                         .withValue(CommonDataKinds.StructuredPostal.STREET, address.getString("street"))
                         .withValue(CommonDataKinds.StructuredPostal.CITY, address.getString("city"))
                         .withValue(CommonDataKinds.StructuredPostal.REGION, address.getString("state"))
@@ -541,7 +541,7 @@ public class ContactsManager extends ReactContextBaseJavaModule {
         ReadableArray emailAddresses = contact.hasKey("emailAddresses") ? contact.getArray("emailAddresses") : null;
         int numOfEmails = 0;
         String[] emails = null;
-		Integer[] emailsTypes = null;
+        Integer[] emailsTypes = null;
         String[] emailsLabels = null;
         String[] emailIds = null;
 
@@ -549,14 +549,14 @@ public class ContactsManager extends ReactContextBaseJavaModule {
             numOfEmails = emailAddresses.size();
             emails = new String[numOfEmails];
             emailIds = new String[numOfEmails];
-			emailsTypes = new Integer[numOfEmails];
+            emailsTypes = new Integer[numOfEmails];
             emailsLabels = new String[numOfEmails];
             for (int i = 0; i < numOfEmails; i++) {
                 ReadableMap emailMap = emailAddresses.getMap(i);
                 emails[i] = emailMap.getString("email");
                 String label = emailMap.getString("label");
                 emailsTypes[i] = mapStringToEmailType(label);
-				emailsLabels[i] = label;
+                emailsLabels[i] = label;
                 emailIds[i] = emailMap.hasKey("id") ? emailMap.getString("id") : null;
             }
         }
@@ -582,7 +582,7 @@ public class ContactsManager extends ReactContextBaseJavaModule {
             postalAddressesType = new Integer[numOfPostalAddresses];
             postalAddressesLabel = new String[numOfPostalAddresses];
             for (int i = 0; i < numOfPostalAddresses; i++) {
-				String postalLabel = postalAddresses.getMap(i).getString("label");
+                String postalLabel = postalAddresses.getMap(i).getString("label");
                 postalAddressesStreet[i] = postalAddresses.getMap(i).getString("street");
                 postalAddressesCity[i] = postalAddresses.getMap(i).getString("city");
                 postalAddressesState[i] = postalAddresses.getMap(i).getString("state");
@@ -621,27 +621,27 @@ public class ContactsManager extends ReactContextBaseJavaModule {
 
         op.withYieldAllowed(true);
 
-		
-        if (phoneNumbers != null) {		
-			// remove existing phoneNumbers first
-			op = ContentProviderOperation.newDelete(ContactsContract.Data.CONTENT_URI)
-					.withSelection(
-						ContactsContract.Data.MIMETYPE  + "=? AND "+ ContactsContract.Data.RAW_CONTACT_ID + " = ?", 
-						new String[]{String.valueOf(CommonDataKinds.Phone.CONTENT_ITEM_TYPE), String.valueOf(rawContactId)}
-					);
-			ops.add(op.build());
-			
-			// add passed phonenumbers
-			for (int i = 0; i < numOfPhones; i++) {
-				op = ContentProviderOperation.newInsert(ContactsContract.Data.CONTENT_URI)
-						.withValue(ContactsContract.Data.RAW_CONTACT_ID, String.valueOf(rawContactId))
-						.withValue(ContactsContract.Data.MIMETYPE, CommonDataKinds.Phone.CONTENT_ITEM_TYPE)
-						.withValue(CommonDataKinds.Phone.NUMBER, phones[i])
-						.withValue(CommonDataKinds.Phone.TYPE, phonesTypes[i])
-						.withValue(CommonDataKinds.Phone.LABEL, phonesLabels[i]);
-				ops.add(op.build());
-			}
-		}
+        
+        if (phoneNumbers != null) {     
+            // remove existing phoneNumbers first
+            op = ContentProviderOperation.newDelete(ContactsContract.Data.CONTENT_URI)
+                    .withSelection(
+                        ContactsContract.Data.MIMETYPE  + "=? AND "+ ContactsContract.Data.RAW_CONTACT_ID + " = ?", 
+                        new String[]{String.valueOf(CommonDataKinds.Phone.CONTENT_ITEM_TYPE), String.valueOf(rawContactId)}
+                    );
+            ops.add(op.build());
+            
+            // add passed phonenumbers
+            for (int i = 0; i < numOfPhones; i++) {
+                op = ContentProviderOperation.newInsert(ContactsContract.Data.CONTENT_URI)
+                        .withValue(ContactsContract.Data.RAW_CONTACT_ID, String.valueOf(rawContactId))
+                        .withValue(ContactsContract.Data.MIMETYPE, CommonDataKinds.Phone.CONTENT_ITEM_TYPE)
+                        .withValue(CommonDataKinds.Phone.NUMBER, phones[i])
+                        .withValue(CommonDataKinds.Phone.TYPE, phonesTypes[i])
+                        .withValue(CommonDataKinds.Phone.LABEL, phonesLabels[i]);
+                ops.add(op.build());
+            }
+        }
 
         for (int i = 0; i < numOfUrls; i++) {
             if (urlIds[i] == null) {
@@ -657,26 +657,26 @@ public class ContactsManager extends ReactContextBaseJavaModule {
             ops.add(op.build());
         }
 
-		if (emailAddresses != null){
-			// remove existing emails first
-			op = ContentProviderOperation.newDelete(ContactsContract.Data.CONTENT_URI)
-					.withSelection(
-						ContactsContract.Data.MIMETYPE  + "=? AND "+ ContactsContract.Data.RAW_CONTACT_ID + " = ?", 
-						new String[]{String.valueOf(CommonDataKinds.Email.CONTENT_ITEM_TYPE), String.valueOf(rawContactId)}
-					);
-			ops.add(op.build());
+        if (emailAddresses != null){
+            // remove existing emails first
+            op = ContentProviderOperation.newDelete(ContactsContract.Data.CONTENT_URI)
+                    .withSelection(
+                        ContactsContract.Data.MIMETYPE  + "=? AND "+ ContactsContract.Data.RAW_CONTACT_ID + " = ?", 
+                        new String[]{String.valueOf(CommonDataKinds.Email.CONTENT_ITEM_TYPE), String.valueOf(rawContactId)}
+                    );
+            ops.add(op.build());
 
-			// add passed email addresses
-			for (int i = 0; i < numOfEmails; i++) {
-				op = ContentProviderOperation.newInsert(ContactsContract.Data.CONTENT_URI)
-						.withValue(ContactsContract.Data.RAW_CONTACT_ID, String.valueOf(rawContactId))
-						.withValue(ContactsContract.Data.MIMETYPE, CommonDataKinds.Email.CONTENT_ITEM_TYPE)
-						.withValue(CommonDataKinds.Email.ADDRESS, emails[i])
-						.withValue(CommonDataKinds.Email.TYPE, emailsTypes[i])
-						.withValue(CommonDataKinds.Email.LABEL, emailsLabels[i]);
-				ops.add(op.build());
-			}
-		}
+            // add passed email addresses
+            for (int i = 0; i < numOfEmails; i++) {
+                op = ContentProviderOperation.newInsert(ContactsContract.Data.CONTENT_URI)
+                        .withValue(ContactsContract.Data.RAW_CONTACT_ID, String.valueOf(rawContactId))
+                        .withValue(ContactsContract.Data.MIMETYPE, CommonDataKinds.Email.CONTENT_ITEM_TYPE)
+                        .withValue(CommonDataKinds.Email.ADDRESS, emails[i])
+                        .withValue(CommonDataKinds.Email.TYPE, emailsTypes[i])
+                        .withValue(CommonDataKinds.Email.LABEL, emailsLabels[i]);
+                ops.add(op.build());
+            }
+        }
 
          if(thumbnailPath != null && !thumbnailPath.isEmpty()) {
             Bitmap photo = BitmapFactory.decodeFile(thumbnailPath);
@@ -690,21 +690,21 @@ public class ContactsManager extends ReactContextBaseJavaModule {
             }
         }
 
-		if (postalAddresses != null){
-			//remove existing addresses
-			 op = ContentProviderOperation.newDelete(ContactsContract.Data.CONTENT_URI)
-					.withSelection(
-						ContactsContract.Data.MIMETYPE  + "=? AND "+ ContactsContract.Data.RAW_CONTACT_ID + " = ?", 
-						new String[]{String.valueOf(CommonDataKinds.StructuredPostal.CONTENT_ITEM_TYPE), String.valueOf(rawContactId)}
-					);
-       		ops.add(op.build());
+        if (postalAddresses != null){
+            //remove existing addresses
+             op = ContentProviderOperation.newDelete(ContactsContract.Data.CONTENT_URI)
+                    .withSelection(
+                        ContactsContract.Data.MIMETYPE  + "=? AND "+ ContactsContract.Data.RAW_CONTACT_ID + " = ?", 
+                        new String[]{String.valueOf(CommonDataKinds.StructuredPostal.CONTENT_ITEM_TYPE), String.valueOf(rawContactId)}
+                    );
+            ops.add(op.build());
 
             for (int i = 0; i < numOfPostalAddresses; i++) {
                 op = ContentProviderOperation.newInsert(ContactsContract.Data.CONTENT_URI)
                         .withValue(ContactsContract.Data.RAW_CONTACT_ID, String.valueOf(rawContactId))
                         .withValue(ContactsContract.Data.MIMETYPE, CommonDataKinds.StructuredPostal.CONTENT_ITEM_TYPE)
                         .withValue(CommonDataKinds.StructuredPostal.TYPE, postalAddressesType[i])
-						.withValue(CommonDataKinds.StructuredPostal.LABEL, postalAddressesLabel[i])
+                        .withValue(CommonDataKinds.StructuredPostal.LABEL, postalAddressesLabel[i])
                         .withValue(CommonDataKinds.StructuredPostal.STREET, postalAddressesStreet[i])
                         .withValue(CommonDataKinds.StructuredPostal.CITY, postalAddressesCity[i])
                         .withValue(CommonDataKinds.StructuredPostal.REGION, postalAddressesState[i])
@@ -837,24 +837,24 @@ public class ContactsManager extends ReactContextBaseJavaModule {
             case "mobile":
                 phoneType = CommonDataKinds.Phone.TYPE_MOBILE;
                 break;
-			case "main":
-				phoneType = CommonDataKinds.Phone.TYPE_MAIN;
-				break;
-			case "work fax":
-				phoneType = CommonDataKinds.Phone.TYPE_FAX_WORK;
-				break;
-			case "home fax":
-				phoneType = CommonDataKinds.Phone.TYPE_FAX_HOME;
-				break;
-			case "pager":
-				phoneType = CommonDataKinds.Phone.TYPE_PAGER;
-				break;
-			case "work_pager":
-				phoneType = CommonDataKinds.Phone.TYPE_WORK_PAGER;
-				break;
-			case "work_mobile":
-				phoneType = CommonDataKinds.Phone.TYPE_WORK_MOBILE;
-				break;
+            case "main":
+                phoneType = CommonDataKinds.Phone.TYPE_MAIN;
+                break;
+            case "work fax":
+                phoneType = CommonDataKinds.Phone.TYPE_FAX_WORK;
+                break;
+            case "home fax":
+                phoneType = CommonDataKinds.Phone.TYPE_FAX_HOME;
+                break;
+            case "pager":
+                phoneType = CommonDataKinds.Phone.TYPE_PAGER;
+                break;
+            case "work_pager":
+                phoneType = CommonDataKinds.Phone.TYPE_WORK_PAGER;
+                break;
+            case "work_mobile":
+                phoneType = CommonDataKinds.Phone.TYPE_WORK_MOBILE;
+                break;
             default:
                 phoneType = CommonDataKinds.Phone.TYPE_CUSTOM;
                 break;


### PR DESCRIPTION
Commit 9ffadc0: 
Added code for updating postal addresses. I'm basically using the same code used in addContact except it updates instead of insert. This addresses issue  #345 

Commit 9a51c5a:
Addresses a few issues with @luucv 's solution to #332 
1. Stop the delete from running if phones/emails are not present as keys in the argument for updateContact.
2. switch from CONTACT_ID to RAW_CONTACT_ID as reference for deleting because there was problem deleting info added by react-native-contacts.

Commit 871bd49:
Allow custom labels.
Before, we only supported TYPE update. We convert labels to type using mapStringToPhoneType function and only updates the type. This only works for Android's default label. Any unrecognized label is default to OTHER TYPE, and the actual value of the label was lost. 
I added support for LABEL update. unrecognized TYPE is now default to CUSTOM, and the label value will be read from actual label instead. 
This is also added to addContact to support custom labels for addContact.
I'm not familiar with openContactForm, so I didn't touch anything for that. 

Note: The duplicate issue (#332 ) may affect uris (Websites) for contacts as well. I'm planning on addressing that at a  much later date if no one else gets to it by then.


 