### PR TITLE
Removing build level warning by moving from compile to implementation

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,5 +35,5 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
While building the project we get the following warning. The solution is very simple. All we have to do is change the keyword from compile to implementation and it works.

```
WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html
```
