### PR TITLE
Fix for update/delete not working on android

### DIFF
--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsProvider.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsProvider.java
@@ -274,7 +274,7 @@ public class ContactsProvider {
             Contact contact = map.get(rawContactId);
             String mimeType = cursor.getString(cursor.getColumnIndex(ContactsContract.Data.MIMETYPE));
             String name = cursor.getString(cursor.getColumnIndex(ContactsContract.Contacts.DISPLAY_NAME));
-            contact.rawContactId = rawContactId;
+            contact.contactId = contactId;
             if (!TextUtils.isEmpty(name) && TextUtils.isEmpty(contact.displayName)) {
                 contact.displayName = name;
             }
@@ -435,8 +435,8 @@ public class ContactsProvider {
         private Birthday birthday;
 
 
-        public Contact(String contactId) {
-            this.contactId = contactId;
+        public Contact(String rawContactId) {
+            this.rawContactId = rawContactId;
         }
 
         public WritableMap toMap() {


### PR DESCRIPTION
Fixes issue where it wasn't possible to update or delete a contact on android.

The issue that both recordID and rawContactId were being set to rawContactId before being returned to the user, which ment it would try to delete or update a contact based on an id which might not exist.