### PR TITLE
Update iOS contactImageData when it changes

### DIFF
--- a/ios/RCTContacts/RCTContacts.m
+++ b/ios/RCTContacts/RCTContacts.m
@@ -337,14 +337,17 @@ RCT_EXPORT_METHOD(getAllWithoutPhotos:(RCTResponseSenderBlock) callback)
 
 -(NSString *) getFilePathForThumbnailImage:(CNContact*) contact recordID:(NSString*) recordID
 {
-    NSString *filepath = [self thumbnailFilePath:recordID];
-
-    if([[NSFileManager defaultManager] fileExistsAtPath:filepath]) {
-        return filepath;
-    }
-
     if (contact.imageDataAvailable){
+        NSString *filepath = [self thumbnailFilePath:recordID];
         NSData *contactImageData = contact.thumbnailImageData;
+
+        if ([[NSFileManager defaultManager] fileExistsAtPath:filepath]) {
+            NSData *existingImageData = [NSData dataWithContentsOfFile: filepath];
+
+            if([contactImageData isEqual: existingImageData]) {
+                return filepath;
+            }
+        }
 
         BOOL success = [[NSFileManager defaultManager] createFileAtPath:filepath contents:contactImageData attributes:nil];
 


### PR DESCRIPTION
addresses issue #169

This fix only applies to iOS

When fetching the file path for a thumbnail image, compare the contact thumbnail image file contents with the currently cached image contents. If they do not match, update the file.