### PR TITLE
Move react-native-cli to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     { "name": "rt2zz <zack@root-two.com>" }
   ],
   "license": "MIT",
-  "dependencies": {
+  "dependencies": {},
+  "devDependencies": {
     "react-native-cli": "^2.0.1"
   }
 }


### PR DESCRIPTION
I recently noticed that upgrading `react-native-contacts` added `react-native-cli` as dependency to my project. Having this as direct dependency for project might cause few issues (like overwriting global rn-cli version).
It was introduced in [this commit](https://github.com/rt2zz/react-native-contacts/commit/20b444b8a776dca498a181c537cab5028a5eeb73). And based on commit description, it should be added as devDependency back then.