### PR TITLE
fix(RCTContacts): Fix thumbnail path missing on string search

### DIFF
--- a/ios/RCTContacts/RCTContacts.m
+++ b/ios/RCTContacts/RCTContacts.m
@@ -85,6 +85,7 @@ RCT_EXPORT_METHOD(getContactsMatchingString:(NSString *)string callback:(RCTResp
                       CNContactOrganizationNameKey,
                       CNContactJobTitleKey,
                       CNContactImageDataAvailableKey,
+                      CNContactThumbnailImageDataKey,
                       CNContactNoteKey,
                       CNContactUrlAddressesKey,
                       CNContactBirthdayKey
@@ -93,7 +94,7 @@ RCT_EXPORT_METHOD(getContactsMatchingString:(NSString *)string callback:(RCTResp
                                                            keysToFetch:keys
                                                                  error:&contactError];
     [arrayOfContacts enumerateObjectsUsingBlock:^(CNContact * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
-        NSDictionary *contactDictionary = [self contactToDictionary:obj withThumbnails:NO];
+        NSDictionary *contactDictionary = [self contactToDictionary:obj withThumbnails:true];
         [contacts addObject:contactDictionary];
     }];
     callback(@[[NSNull null], contacts]);


### PR DESCRIPTION
This PR is to allow thumbnail pictures to show on search. For whatever reasons, it was disabled.