### PR TITLE
fix podspec file

### DIFF
--- a/react-native-contacts.podspec
+++ b/react-native-contacts.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license        = package_json["license"]
   s.author         = { package_json["author"] => package_json["author"] }
   s.platform       = :ios, "9.0"
-  s.source         = { :git => package_json["repository"]["url"] }
+  s.source         = { :git => "https://github.com/rt2zz/react-native-contacts.git" } 
   s.source_files   = 'ios/RCTContacts/*.{h,m}'
 
   s.dependency 'React'


### PR DESCRIPTION
fix cocoapods error "fatal: unable to find remote helper for 'git+https'"  => add explicit git repo source URL in podspec file