### PR TITLE
Contacts.getContactById throws exception on IOS when passing recordID…

### DIFF
--- a/ios/RCTContacts/RCTContacts.m
+++ b/ios/RCTContacts/RCTContacts.m
@@ -479,6 +479,9 @@ RCT_EXPORT_METHOD(getContactById:(nonnull NSString *)recordID callback:(RCTRespo
                       ];
     CNContact* contact = [addressBook unifiedContactWithIdentifier:recordID keysToFetch:keysToFetch error:&contactError];
 
+    if(!contact)
+            return nil;
+
     return [self contactToDictionary: contact withThumbnails:withThumbnails];
 }
 


### PR DESCRIPTION
Contacts.getContactById throws exception on IOS when passing recordID that no longer exists 

fixes #426