### PR TITLE
Add contacts count feature

### DIFF
--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
@@ -107,6 +107,24 @@ public class ContactsManager extends ReactContextBaseJavaModule implements Activ
         myAsyncTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
     }
 
+    @ReactMethod
+    public void getCount(final Callback callback) {
+        AsyncTask<Void,Void,Void> myAsyncTask = new AsyncTask<Void,Void,Void>() {
+            @Override
+            protected Void doInBackground(final Void ... params) {
+                Context context = getReactApplicationContext();
+                ContentResolver cr = context.getContentResolver();
+
+                ContactsProvider contactsProvider = new ContactsProvider(cr);
+                Integer contacts = contactsProvider.getContactsCount();
+
+                callback.invoke(contacts);
+                return null;
+            }
+        };
+        myAsyncTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+    }
+
     /**
      * Retrieves contacts matching String.
      * Uses raw URI when <code>rawUri</code> is <code>true</code>, makes assets copy otherwise.

--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsProvider.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsProvider.java
@@ -199,6 +199,13 @@ public class ContactsProvider {
        return null;
     }
 
+    public Integer getContactsCount() {
+        Cursor cursor =  contentResolver.query(ContactsContract.Contacts.CONTENT_URI, null, null, null, null);
+        int count = cursor.getCount();
+        
+        return count;
+    }
+
     public WritableArray getContacts() {
         Map<String, Contact> justMe;
         {

--- a/example/App.js
+++ b/example/App.js
@@ -31,7 +31,8 @@ export default class App extends Component<Props> {
     this.search = this.search.bind(this);
 
     this.state = {
-      contacts: []
+      contacts: [],
+      searchPlaceholder: "Search"
     };
   }
 
@@ -55,6 +56,10 @@ export default class App extends Component<Props> {
       } else {
         this.setState({ contacts });
       }
+    });
+
+    Contacts.getCount(count => {
+      this.setState({ searchPlaceholder: `Search ${count} contacts` });
     });
   }
 
@@ -92,7 +97,10 @@ export default class App extends Component<Props> {
             }}
           />
         </View>
-        <SearchBar onChangeText={this.search} />
+        <SearchBar
+          searchPlaceholder={this.state.searchPlaceholder}
+          onChangeText={this.search}
+        />
         <ScrollView style={{ flex: 1 }}>
           {this.state.contacts.map(contact => {
             return (

--- a/ios/RCTContacts/RCTContacts.m
+++ b/ios/RCTContacts/RCTContacts.m
@@ -148,6 +148,46 @@ RCT_EXPORT_METHOD(getContactsByPhoneNumber:(NSString *)string callback:(RCTRespo
     [self retrieveContactsFromAddressBook:contactStore withThumbnails:withThumbnails withCallback:callback];
 }
 
+-(void) getAllContactsCount:(RCTResponseSenderBlock) callback
+{
+    CNContactStore* contactStore = [self contactsStore:callback];
+    if(!contactStore)
+        return;
+
+    NSMutableArray *contacts = [[NSMutableArray alloc] init];
+
+    NSError* contactError;
+    [contactStore containersMatchingPredicate:[CNContainer predicateForContainersWithIdentifiers: @[contactStore.defaultContainerIdentifier]] error:&contactError];
+
+
+    NSMutableArray *keysToFetch = [[NSMutableArray alloc]init];
+    [keysToFetch addObjectsFromArray:@[
+                                       CNContactEmailAddressesKey,
+                                       CNContactPhoneNumbersKey,
+                                       CNContactFamilyNameKey,
+                                       CNContactGivenNameKey,
+                                       CNContactMiddleNameKey,
+                                       CNContactPostalAddressesKey,
+                                       CNContactOrganizationNameKey,
+                                       CNContactJobTitleKey,
+                                       CNContactImageDataAvailableKey,
+                                       CNContactUrlAddressesKey,
+                                       CNContactBirthdayKey
+                                       ]];
+
+    CNContactFetchRequest * request = [[CNContactFetchRequest alloc]initWithKeysToFetch:keysToFetch];
+    BOOL success = [contactStore enumerateContactsWithFetchRequest:request error:&contactError usingBlock:^(CNContact * __nonnull contact, BOOL * __nonnull stop){
+        NSDictionary *contactDict = [self contactToDictionary: contact withThumbnails:false];
+        [contacts addObject:contactDict];
+    }];
+
+    int contactsCount = [contacts count];
+
+    NSNumber *count = [NSNumber numberWithInt:contactsCount];
+
+    callback(@[count]);
+}
+
 RCT_EXPORT_METHOD(getAll:(RCTResponseSenderBlock) callback)
 {
     [self getAllContacts:callback withThumbnails:true];
@@ -156,6 +196,11 @@ RCT_EXPORT_METHOD(getAll:(RCTResponseSenderBlock) callback)
 RCT_EXPORT_METHOD(getAllWithoutPhotos:(RCTResponseSenderBlock) callback)
 {
     [self getAllContacts:callback withThumbnails:false];
+}
+
+RCT_EXPORT_METHOD(getCount:(RCTResponseSenderBlock) callback)
+{
+    [self getAllContactsCount:callback];
 }
 
 -(void) retrieveContactsFromAddressBook:(CNContactStore*)contactStore


### PR DESCRIPTION
Added methods for iOS and Android to return a count of all contacts. iOS loops over all contacts to get the total - may be a better way of doing this.

You can test it by running:
```
Contacts.getCount(count => {
  console.log('Total contacts: ' + count);
});
```