### PR TITLE
Fix empty urlAddresses on Android

### DIFF
--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsProvider.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsProvider.java
@@ -411,6 +411,43 @@ public class ContactsProvider {
                         contact.emails.add(new Contact.Item(label, email, id));
                     }
                     break;
+                case Website.CONTENT_ITEM_TYPE:
+                    String url = cursor.getString(cursor.getColumnIndex(Website.URL));
+                    int websiteType = cursor.getInt(cursor.getColumnIndex(Website.TYPE));
+                    if (!TextUtils.isEmpty(url)) {
+                        String label;
+                        switch (websiteType) {
+                            case Website.TYPE_HOMEPAGE:
+                                label = "homepage";
+                                break;
+                            case Website.TYPE_BLOG:
+                                label = "blog";
+                                break;
+                            case Website.TYPE_PROFILE:
+                                label = "profile";
+                                break;
+                            case Website.TYPE_HOME:
+                                label = "home";
+                                break;
+                            case Website.TYPE_WORK:
+                                label = "work";
+                                break;
+                            case Website.TYPE_FTP:
+                                label = "ftp";
+                                break;
+                            case Website.TYPE_CUSTOM:
+                                if (cursor.getString(cursor.getColumnIndex(Website.LABEL)) != null) {
+                                    label = cursor.getString(cursor.getColumnIndex(Website.LABEL)).toLowerCase();
+                                } else {
+                                    label = "";
+                                }
+                                break;
+                            default:
+                                label = "other";
+                        }
+                        contact.urls.add(new Contact.Item(label, url, id));
+                    }
+                    break;
                 case Organization.CONTENT_ITEM_TYPE:
                     contact.company = cursor.getString(cursor.getColumnIndex(Organization.COMPANY));
                     contact.jobTitle = cursor.getString(cursor.getColumnIndex(Organization.TITLE));


### PR DESCRIPTION
When I request contacts data on android using `getAllContacts` method, I receive empty array with `urlAddresses` even when the contact has Website data.

It happens because we don't map `Website.CONTENT_ITEM_TYPE` record to contacts data.

This PR fixes it.

Support for urlAddresses was introduced in PR https://github.com/rt2zz/react-native-contacts/pull/329

Here is related issue which should be also fixed by this PR https://github.com/rt2zz/react-native-contacts/issues/436
fixes https://github.com/rt2zz/react-native-contacts/issues/436