### PR TITLE
Fix install instructions for RN >= 0.60.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,17 @@ target 'app' do
 end
 ```
 
+- Add the following line inside `ios/yourProject/Info.plist`
+
+```
+<dict>
+  ...
+  <key>NSContactsUsageDescription</key>
+  <string>Reason your app needs permission to access contacts</string>
+  ...
+</dict>
+```
+
 - Run `pod install` in folder `ios`
 
 


### PR DESCRIPTION
Based on Issue https://github.com/rt2zz/react-native-contacts/issues/448.

The following must be added to `ios/yourProject/Info.plist` for ALL versions of React Native, but current README only specifies this step for versions older than 0.60.x. Added this step to instruction set for RN versions >= 0.60.x.

```
<key>NSContactsUsageDescription</key>
<string>Reason your app needs permission to access contacts</string>
```