### PR TITLE
Remove contacts permission from manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ public class MainApplication extends Application implements ReactApplication {
 #### Permissions
 ##### API 23+
 Android requires allowing permissions with https://facebook.github.io/react-native/docs/permissionsandroid.html
-The `READ_CONTACTS` permission is automatically added to `AndroidManifest.xml`, so you just need request it. If your app creates contacts add `WRITE_CONTACTS` permission to `AndroidManifest.xml` and request the permission at runtime.
+The `READ_CONTACTS` permission must be added to your main application's `AndroidManifest.xml`. If your app creates contacts add `WRITE_CONTACTS` permission to `AndroidManifest.xml` and request the permission at runtime.
 ```xml
 ...
 <uses-permission android:name="android.permission.WRITE_CONTACTS" />

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -2,7 +2,4 @@
 <manifest
   xmlns:android="http://schemas.android.com/apk/res/android"
   package="com.rt2zz.reactnativecontacts" >
-
-  <uses-permission android:name="android.permission.READ_CONTACTS" />
-
 </manifest>


### PR DESCRIPTION
Certain applications that target Android os versions prior to SDK 23 (Android M) may want to opt out of using contacts all together on those downlevel os versions since they require the user to agree to the contacts permission when a user installs the application.