### PR TITLE
Fix Android null birthday crash

### DIFF
--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsProvider.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsProvider.java
@@ -480,7 +480,7 @@ public class ContactsProvider {
                                     contact.birthday = new Contact.Birthday(year, month, day);
                                 }
                             }
-                        } catch (NumberFormatException | ArrayIndexOutOfBoundsException e) {
+                        } catch (NumberFormatException | ArrayIndexOutOfBoundsException | NullPointerException e) {
                             // whoops, birthday isn't in the format we expect
                             Log.w("ContactsProvider", e.toString());
 


### PR DESCRIPTION
On Android, in certain cases, the string returned from the contacts db was null, and NullPointerException was unhandled resulting in a crash. This PR handles the exception so if a contact has a null birthday, we can still import the contact excluding the birthday, and the app won't crash. I'm not sure why some contacts' birthdays were coming back as null and could not replicate it on my end, but hopefully this fixes #355  in the sense that it won't crash anymore :P 

fixes #355 