### PR TITLE
fix(android): use SERIAL_EXECUTOR instead of THREAD_POOL_EXECUTOR

### DIFF
--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
@@ -21,7 +21,6 @@ import android.provider.ContactsContract.CommonDataKinds;
 import android.provider.ContactsContract.CommonDataKinds.Organization;
 import android.provider.ContactsContract.CommonDataKinds.StructuredName;
 import android.provider.ContactsContract.CommonDataKinds.Note;
-import android.provider.ContactsContract.CommonDataKinds.Website;
 import android.provider.ContactsContract.RawContacts;
 import androidx.annotation.NonNull;
 import androidx.core.app.ActivityCompat;
@@ -35,7 +34,6 @@ import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableArray;
-import com.facebook.react.bridge.Arguments;
 
 import java.io.ByteArrayOutputStream;
 import java.io.FileNotFoundException;
@@ -44,7 +42,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.io.InputStream;
-import java.io.IOException;
 import java.util.Hashtable;
 
 public class ContactsManager extends ReactContextBaseJavaModule implements ActivityEventListener {
@@ -104,7 +101,7 @@ public class ContactsManager extends ReactContextBaseJavaModule implements Activ
                 return null;
             }
         };
-        myAsyncTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+        myAsyncTask.executeOnExecutor(AsyncTask.SERIAL_EXECUTOR);
     }
 
     @ReactMethod
@@ -122,7 +119,7 @@ public class ContactsManager extends ReactContextBaseJavaModule implements Activ
                 return null;
             }
         };
-        myAsyncTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+        myAsyncTask.executeOnExecutor(AsyncTask.SERIAL_EXECUTOR);
     }
 
     /**
@@ -146,7 +143,7 @@ public class ContactsManager extends ReactContextBaseJavaModule implements Activ
                 return null;
             }
         };
-        myAsyncTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+        myAsyncTask.executeOnExecutor(AsyncTask.SERIAL_EXECUTOR);
     }
 
     /**
@@ -170,7 +167,7 @@ public class ContactsManager extends ReactContextBaseJavaModule implements Activ
                 return null;
             }
         };
-        myAsyncTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+        myAsyncTask.executeOnExecutor(AsyncTask.SERIAL_EXECUTOR);
     }
 
     /**
@@ -194,7 +191,7 @@ public class ContactsManager extends ReactContextBaseJavaModule implements Activ
                 return null;
             }
         };
-        myAsyncTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+        myAsyncTask.executeOnExecutor(AsyncTask.SERIAL_EXECUTOR);
     }
 
     /**
@@ -217,7 +214,7 @@ public class ContactsManager extends ReactContextBaseJavaModule implements Activ
                 return null;
             }
         };
-        myAsyncTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+        myAsyncTask.executeOnExecutor(AsyncTask.SERIAL_EXECUTOR);
     }
 
     /**
@@ -240,7 +237,7 @@ public class ContactsManager extends ReactContextBaseJavaModule implements Activ
                 return null;
             }
         };
-        myAsyncTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+        myAsyncTask.executeOnExecutor(AsyncTask.SERIAL_EXECUTOR);
     }
 
     @ReactMethod
@@ -275,7 +272,7 @@ public class ContactsManager extends ReactContextBaseJavaModule implements Activ
                 return null;
             }
         };
-        myAsyncTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+        myAsyncTask.executeOnExecutor(AsyncTask.SERIAL_EXECUTOR);
     }
 
     private Bitmap getThumbnailBitmap(String thumbnailPath) {


### PR DESCRIPTION
We are using a lot `getContactsByPhoneNumber` to retrieve a bunch of contacts. But if your address book is big and you are looking for a lot, some users have ThreadPool error.

![image](https://user-images.githubusercontent.com/1246630/73761080-4df91200-473c-11ea-9361-9bdc1f8c9d2b.png)

With AsyncTask.THREAD_POOL_EXECUTOR we are able to stack 5 threads in the same time and we could  stack 128 threads  => https://medium.com/@arj.sna/android-multiple-asynctasks-78b2f847a2ec

In fact, we don't really have all this method in parallel. The serial mode is good enough and the thread pool size has no limit.
  
