### PR TITLE
Let `openContactForm` result be `Promise<Contact | null>`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@ export function getContactById(contactId: string): Promise<Contact | null>;
 export function getCount(): Promise<number>;
 export function getPhotoForId(contactId: string): Promise<string>;
 export function addContact(contact: Partial<Contact>): Promise<Contact>;
-export function openContactForm(contact: Partial<Contact>): Promise<Contact>;
+export function openContactForm(contact: Partial<Contact>): Promise<Contact | null>;
 export function openExistingContact(contact: Contact): Promise<Contact>;
 export function viewExistingContact(contact: { recordID: string }): Promise<Contact | void>
 export function editExistingContact(contact: Contact): Promise<Contact>;


### PR DESCRIPTION
Once the dialog is opened using `openContactForm` a user can save a contact or dismiss the dialog. When a user dismisses the dialog, the promise value will be `null`.

This change aims to align the API typing with the actual behavior