### PR TITLE
Make iOS only specs as optional

### DIFF
--- a/src/NativeContacts.ts
+++ b/src/NativeContacts.ts
@@ -22,20 +22,20 @@ export interface Spec extends TurboModule {
   requestPermission: () => Promise<PermissionType>;
   writePhotoToPath: (contactId: string, file: string) => Promise<boolean>;
   iosEnableNotesUsage: (enabled: boolean) => void;
-  getGroups(): Promise<Group[]>;
-  getGroup: (identifier: string) => Promise<Group | null>;
-  deleteGroup(identifier: string): Promise<boolean>;
-  updateGroup(identifier: string, groupData: Object): Promise<Group>;
-  addGroup(group: Object): Promise<Group>;
-  contactsInGroup(identifier: string): Promise<Contact[]>;
-  addContactsToGroup(
+  getGroups?: () => Promise<Group[]>;
+  getGroup?: (identifier: string) => Promise<Group | null>;
+  deleteGroup?: (identifier: string) => Promise<boolean>;
+  updateGroup?: (identifier: string, groupData: Object) => Promise<Group>;
+  addGroup?: (group: Object) => Promise<Group>;
+  contactsInGroup?: (identifier: string) => Promise<Contact[]>;
+  addContactsToGroup?: (
     groupIdentifier: string,
     contactIdentifiers: string[]
-  ): Promise<boolean>;
-  removeContactsFromGroup(
+  ) => Promise<boolean>;
+  removeContactsFromGroup?: (
     groupIdentifier: string,
     contactIdentifiers: string[]
-  ): Promise<boolean>;
+  ) => Promise<boolean>;
 }
 
 export default TurboModuleRegistry.get<Spec>("RCTContacts");


### PR DESCRIPTION
After update `react-native-contacts` to `8.0.5` I faced with

```
public class ContactsManager extends NativeContactsSpec implements ActivityEventListener
```

because of new iOS group specific functions not implemented on Android

Repro:
https://github.com/Bardiamist/diff/tree/contacts
1. Add react-native-contacts
2. [Add Turbo Module ](https://reactnative.dev/docs/0.78/turbo-native-modules-introduction?platforms=android)
3. cd android && ./gradlew generateCodegenArtifactsFromSchema

So iOS group specific functions should be optional