### PR TITLE
Fix Legacy Bridge

### DIFF
--- a/ios/RCTContacts/RCTContacts.h
+++ b/ios/RCTContacts/RCTContacts.h
@@ -1,19 +1,16 @@
 #import <React/RCTBridgeModule.h>
 #import <Contacts/Contacts.h>
 #import <ContactsUI/ContactsUI.h>
-#import <Foundation/Foundation.h>
-
 #ifdef RCT_NEW_ARCH_ENABLED
-
 #import <RNContactsSpec/RNContactsSpec.h>
-@interface RCTContacts: NSObject <NativeContactsSpec, CNContactViewControllerDelegate>
-
-#else
-
-#import <React/RCTBridgeModule.h>
-@interface RCTContacts : NSObject <RCTBridgeModule, CNContactViewControllerDelegate>
-
 #endif
+
+@interface RCTContacts : NSObject <RCTBridgeModule, CNContactViewControllerDelegate>
 
 @end
 
+#ifdef RCT_NEW_ARCH_ENABLED
+@interface RCTContacts: NSObject <NativeContactsSpec, CNContactViewControllerDelegate>
+
+@end
+#endif

--- a/ios/RCTContacts/RCTContacts.mm
+++ b/ios/RCTContacts/RCTContacts.mm
@@ -63,7 +63,7 @@ RCT_EXPORT_METHOD(checkPermission:(RCTPromiseResolveBlock)resolve
     } else if (authStatus == CNAuthorizationStatusAuthorized) {
         resolve(@"authorized");
     } else if (@available(iOS 18, *)) {
-        if (authStatus == CNAuthorizationStatusRestricted) {
+        if (authStatus == CNAuthorizationStatusLimited) {
             resolve(@"limited");
         } else {
             resolve(@"undefined");


### PR DESCRIPTION
## Summary

- fix `checkPermission` function
- fix integration of new and old architecture as described in the [docs](https://github.com/reactwg/react-native-new-architecture/blob/main/docs/backwards-compat-turbo-modules.md)