### PR TITLE
fix iOS checkPermission limited promise check

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -24,10 +24,10 @@ export function getContactsByEmailAddress(
   emailAddress: string
 ): Promise<Contact[]>;
 export function checkPermission(): Promise<
-  "authorized" | "denied" | "undefined"
+  "authorized" | "denied" | "undefined" | "limited"
 >;
 export function requestPermission(): Promise<
-  "authorized" | "denied" | "undefined"
+  "authorized" | "denied" | "undefined" | "limited"
 >;
 export function writePhotoToPath(
   contactId: string,

--- a/ios/RCTContacts/RCTContacts.mm
+++ b/ios/RCTContacts/RCTContacts.mm
@@ -63,7 +63,7 @@ RCT_EXPORT_METHOD(checkPermission:(RCTPromiseResolveBlock)resolve
     } else if (authStatus == CNAuthorizationStatusAuthorized) {
         resolve(@"authorized");
     } else if (@available(iOS 18, *)) {
-        if (authStatus == CNAuthorizationStatusRestricted) {
+        if (authStatus == CNAuthorizationStatusLimited) {
             resolve(@"limited");
         } else {
             resolve(@"undefined");


### PR DESCRIPTION
with iOS 18, introduced limited permission status. Restricted is relevant with parental control and it's also checked on [line 61](https://github.com/morenoh149/react-native-contacts/compare/master...omerkarakose:react-native-contacts:patch-1#diff-9f519ef5ca45a243466820543c6edcd520bdda68126db027405456f6c63a13e2R61).

**CNAuthorizationStatusRestricted**
> The application is not authorized to access contact data. The user cannot change this application’s status, possibly due to active restrictions such as parental controls being in place.
See: https://developer.apple.com/documentation/contacts/cnauthorizationstatus/restricted


**CNAuthorizationStatusLimited**
> The app has access to a limited subset of contacts, chosen by the person using the app.
See: https://developer.apple.com/documentation/contacts/cnauthorizationstatus/limited?language=objc

This check needs to be changed with limited.