### PR TITLE
fix(ios): avoid duplicate RCTContacts interfaces when RCT_NEW_ARCH_ENABLED is enabled

### DIFF
--- a/ios/RCTContacts/RCTContacts.h
+++ b/ios/RCTContacts/RCTContacts.h
@@ -5,12 +5,10 @@
 #import <RNContactsSpec/RNContactsSpec.h>
 #endif
 
-@interface RCTContacts : NSObject <RCTBridgeModule, CNContactViewControllerDelegate>
-
-@end
-
 #ifdef RCT_NEW_ARCH_ENABLED
-@interface RCTContacts: NSObject <NativeContactsSpec, CNContactViewControllerDelegate>
+@interface RCTContacts : NSObject <NativeContactsSpec, CNContactViewControllerDelegate>
+#else
+@interface RCTContacts : NSObject <RCTBridgeModule, CNContactViewControllerDelegate>
+#endif
 
 @end
-#endif


### PR DESCRIPTION
PR #719 leaves the legacy RCTContacts interface unguarded and adds a second RCTContacts interface under RCT_NEW_ARCH_ENABLED, so when New Architecture is enabled the iOS build fails with Duplicate interface definition for class 'RCTContacts'.